### PR TITLE
feat: inherit previous move velocity when move transition is occurred repeatedly

### DIFF
--- a/src/vue/SpringTransition.ts
+++ b/src/vue/SpringTransition.ts
@@ -67,7 +67,7 @@ export function useTransitionHooks(
           ...props.springStyle,
           ...props.enterFrom,
         },
-        false,
+        { animate: false },
       )
 
       forceReflow()
@@ -91,7 +91,7 @@ export function useTransitionHooks(
     const el = _el as HTMLElementWithController
     if (!el[scKey]) {
       el[scKey] = createAnimateController(createStyleSetter(el))
-      el[scKey].setStyle(props.springStyle, false)
+      el[scKey].setStyle(props.springStyle, { animate: false })
 
       forceReflow()
     }
@@ -124,7 +124,7 @@ export function useTransitionHooks(
         ...props.springStyle,
         ...props.enterFrom,
       },
-      false,
+      { animate: false },
     )
 
     emit('afterLeave', _el)

--- a/src/vue/SpringTransitionGroup.ts
+++ b/src/vue/SpringTransitionGroup.ts
@@ -167,7 +167,7 @@ const SpringTransitionGroup = defineComponent({
             ...props.springStyle,
             transform: `translate(${dx}px, ${dy}px)`,
           },
-          false,
+          { animate: false },
         )
 
         return true

--- a/src/vue/SpringTransitionGroup.ts
+++ b/src/vue/SpringTransitionGroup.ts
@@ -54,6 +54,7 @@ interface Position {
 
 const positionMap = new WeakMap<VNode, Position>()
 const newPositionMap = new WeakMap<VNode, Position>()
+const velocityMap = new WeakMap<VNode, Record<string, number[]>>()
 
 const SpringTransitionGroup = defineComponent({
   name: 'SpringTransitionGroup',
@@ -127,6 +128,9 @@ const SpringTransitionGroup = defineComponent({
         const el = child.el as HTMLElementWithController
         const controller = el[scKey]
         if (controller) {
+          // Save current velocity to apply it to the next animation.
+          velocityMap.set(child, { ...controller.realVelocity })
+
           // Do not call setStyle here as it records wrong velocity.
           controller.stop()
 
@@ -178,10 +182,18 @@ const SpringTransitionGroup = defineComponent({
       moved.forEach((child) => {
         const el = child.el as HTMLElementWithController
         const controller = el[scKey]!
-        controller.setStyle({
-          ...props.springStyle,
-          transform: 'translate(0px, 0px)',
-        })
+
+        const velocity = velocityMap.get(child)
+
+        controller.setStyle(
+          {
+            ...props.springStyle,
+            transform: 'translate(0px, 0px)',
+          },
+          {
+            velocity,
+          },
+        )
       })
     })
 

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -68,7 +68,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
   })
 
   watch(input, (input) => {
-    controller.setStyle(input, !disabled.value)
+    controller.setStyle(input, { animate: !disabled.value })
   })
 
   watch(optionsRef, (options) => {

--- a/test/core/controller.test.ts
+++ b/test/core/controller.test.ts
@@ -29,7 +29,7 @@ describe('AnimationController', () => {
     })
     controller.setStyle({ width: `100px` })
     expect(actual).toEqual({ width: '100px', transition: '', [t]: '' })
-    controller.setStyle({ width: `200px` }, false)
+    controller.setStyle({ width: `200px` }, { animate: false })
     expect(actual).toEqual({ width: '200px', transition: '', [t]: '' })
   })
 
@@ -116,9 +116,9 @@ describe('AnimationController', () => {
 
   test('realVelocity is calculated from value history without animation', () => {
     const controller = createAnimateController(() => {})
-    controller.setStyle({ transform: `100px 200px` }, false)
-    controller.setStyle({ transform: `101px 200px` }, false)
-    controller.setStyle({ transform: `102px 200px` }, false)
+    controller.setStyle({ transform: `100px 200px` }, { animate: false })
+    controller.setStyle({ transform: `101px 200px` }, { animate: false })
+    controller.setStyle({ transform: `102px 200px` }, { animate: false })
     expect(controller.realVelocity.transform?.[0]).not.toBe(0)
     expect(controller.realVelocity.transform?.[1]).toBe(0)
   })
@@ -129,7 +129,7 @@ describe('AnimationController', () => {
       style = _style
     })
     controller.setOptions({ duration: 10 })
-    controller.setStyle({ width: '100px' }, false)
+    controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
 
     return new Promise<void>((resolve) => {
@@ -147,7 +147,7 @@ describe('AnimationController', () => {
       style = _style
     })
     controller.setOptions({ duration: 100 })
-    controller.setStyle({ width: '100px' }, false)
+    controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
 
     return new Promise<void>((resolve) => {
@@ -161,12 +161,9 @@ describe('AnimationController', () => {
   })
 
   test('stopped == true when animation is stopped by a new animation', () => {
-    let style: any
-    const controller = createAnimateController((_style) => {
-      style = _style
-    })
+    const controller = createAnimateController(() => {})
     controller.setOptions({ duration: 100 })
-    controller.setStyle({ width: '100px' }, false)
+    controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
 
     return new Promise<void>((resolve) => {

--- a/test/vue/SpringTransition.test.ts
+++ b/test/vue/SpringTransition.test.ts
@@ -54,7 +54,10 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
   })
 
@@ -110,7 +113,10 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = false
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 1 },
+      { animate: false },
+    )
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
 
@@ -136,7 +142,10 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
 
     mockController?.setStyle.mockClear()
@@ -168,7 +177,10 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = false
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 1 },
+      { animate: false },
+    )
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 })
 
     mockController?.setStyle.mockClear()
@@ -200,7 +212,10 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
 
     mockController?.setStyle.mockClear()
@@ -212,7 +227,10 @@ describe('SpringTransition', () => {
     mockController?.setStyle.mockClear()
     await wait(20)
     expect(mockController?.setStyle).toHaveBeenCalledOnce()
-    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(mockController?.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
   })
 
   test('trigger before-enter event before setting style', () => {
@@ -273,7 +291,7 @@ describe('SpringTransition', () => {
             try {
               expect(mockController?.setStyle).toHaveBeenCalledWith(
                 { opacity: 0 },
-                false,
+                { animate: false },
               )
               expect(mockController?.setStyle).toHaveBeenCalledWith({
                 opacity: 1,
@@ -382,7 +400,7 @@ describe('SpringTransition', () => {
             try {
               expect(mockController?.setStyle).toHaveBeenCalledWith(
                 { opacity: 1 },
-                false,
+                { animate: false },
               )
               expect(mockController?.setStyle).toHaveBeenCalledWith({
                 opacity: 0,

--- a/test/vue/SpringTransitionGroup.test.ts
+++ b/test/vue/SpringTransitionGroup.test.ts
@@ -50,7 +50,10 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller: AnimationController<any> = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(controller.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
   })
 
@@ -112,7 +115,10 @@ describe('SpringTransitionGroup', () => {
     vm.list = []
     await nextTick()
 
-    expect(el[scKey].setStyle).toHaveBeenCalledWith({ opacity: 1 }, false)
+    expect(el[scKey].setStyle).toHaveBeenCalledWith(
+      { opacity: 1 },
+      { animate: false },
+    )
     expect(el[scKey].setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
 
@@ -140,7 +146,10 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, false)
+    expect(controller.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: false },
+    )
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
     controller.setStyle.mockClear()
 
@@ -176,7 +185,10 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, false)
+    expect(controller.setStyle).toHaveBeenCalledWith(
+      { opacity: 1 },
+      { animate: false },
+    )
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
     controller.setStyle.mockClear()
 
@@ -212,14 +224,20 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, false)
+    expect(controller.setStyle).toHaveBeenCalledWith(
+      { opacity: 1 },
+      { animate: false },
+    )
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
     controller.setStyle.mockClear()
 
     await wait(20)
 
     expect(controller.setStyle).toHaveBeenCalledTimes(1)
-    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0.5 }, false)
+    expect(controller.setStyle).toHaveBeenCalledWith(
+      { opacity: 0.5 },
+      { animate: false },
+    )
   })
 
   test('force finish enter animation when move processing is triggered', async () => {
@@ -340,7 +358,7 @@ describe('SpringTransitionGroup', () => {
               const controller = this.$refs.els[0][scKey]
               expect(controller.setStyle).toHaveBeenCalledWith(
                 { opacity: 0 },
-                false,
+                { animate: false },
               )
               expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
               resolve()
@@ -450,7 +468,7 @@ describe('SpringTransitionGroup', () => {
               const controller = el[scKey]
               expect(controller.setStyle).toHaveBeenCalledWith(
                 { opacity: 1 },
-                false,
+                { animate: false },
               )
               expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
               resolve()


### PR DESCRIPTION
This change makes frequently happened move animation more natural.

Before:

https://github.com/ktsn/css-spring-animation/assets/2194624/2e35c84b-d16d-4f64-bd50-0cd99610da3f

After:

https://github.com/ktsn/css-spring-animation/assets/2194624/8c15f2f2-987d-4ce0-9327-565d0dff8189

