### PR TITLE
feat: Deprecate useSpring composable

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -365,6 +365,8 @@ const list = ref([
 
 ### `useSpring` composable
 
+> **非推奨**。代わりに [`<spring>` コンポーネント](#spring-component) を使用してください。`realValue` / `realVelocity` が必要な場合は [`springValue`](#springvalueinitial) を使用してください。
+
 スプリングアニメーションを適用した style オブジェクトを返す composable 関数です。また、現在のスタイル中の数値の実際の値と、速度も返します。これらは、スタイルオブジェクトと同じ形式のオブジェクトで、値が数値の配列になっています。
 
 第一引数はアニメーションさせるスタイルを返す関数、または ref です。第二引数はオプションオブジェクトです。これも関数、または ref にすることができます。

--- a/README.ja.md
+++ b/README.ja.md
@@ -365,7 +365,7 @@ const list = ref([
 
 ### `useSpring` composable
 
-> **非推奨**。代わりに [`<spring>` コンポーネント](#spring-component) を使用してください。`realValue` / `realVelocity` が必要な場合は [`springValue`](#springvalueinitial) を使用してください。
+> **非推奨**。代わりに [`<spring>` コンポーネント](#spring-コンポーネント) を使用してください。`realValue` / `realVelocity` が必要な場合は [`springValue`](#springvalueinitial) を使用してください。
 
 スプリングアニメーションを適用した style オブジェクトを返す composable 関数です。また、現在のスタイル中の数値の実際の値と、速度も返します。これらは、スタイルオブジェクトと同じ形式のオブジェクトで、値が数値の配列になっています。
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ const list = ref([
 
 ### `useSpring` composable
 
+> **Deprecated.** Prefer the [`<spring>` component](#spring-component). If you need access to `realValue` / `realVelocity`, use [`springValue`](#springvalueinitial) instead.
+
 A composable function to generate spring animation style. It also returns the real value and velocity of the corresponding number in the style value. They are as same shape as the style value except that its values are the array of numbers.
 
 The first argument is a function or ref that returns the style object to be animated. The second argument is an options object. It also can be a function or ref that returns the options.

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,7 +1,7 @@
 export { spring } from './spring-element'
 export { default as SpringTransition } from './SpringTransition'
 export { default as SpringTransitionGroup } from './SpringTransitionGroup'
-export { useSpring } from './use-spring'
+export { useSpringPublic as useSpring } from './use-spring'
 export { springValue, springComputed } from './spring-value'
 export { springDirectives } from './directives'
 

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -36,6 +36,25 @@ export interface UseSpringResult<Values extends Record<string, number[]>> {
   onSettleCurrent: (fn: (data: { stopped: boolean }) => void) => void
 }
 
+let warnedUseSpring = false
+
+/**
+ * @deprecated Use the `<spring>` component instead. If you need `realValue` or
+ * `realVelocity`, use `springValue`.
+ */
+export function useSpringPublic<Style extends Record<string, AnimateValue>>(
+  styleMapper: RefOrGetter<Style>,
+  options?: MaybeRefOrGetter<UseSpringOptions>,
+): UseSpringResult<Record<keyof Style, number[]>> {
+  if (!warnedUseSpring) {
+    warnedUseSpring = true
+    console.warn(
+      '[css-spring-animation] `useSpring` is deprecated. Use the `<spring>` component instead. If you need `realValue` or `realVelocity`, use `springValue`.',
+    )
+  }
+  return useSpring(styleMapper, options)
+}
+
 export function useSpring<Style extends Record<string, AnimateValue>>(
   styleMapper: RefOrGetter<Style>,
   options?: MaybeRefOrGetter<UseSpringOptions>,


### PR DESCRIPTION
## Summary

- Deprecates the `useSpring` composable. Calling it now emits a one-shot `console.warn` directing users to the `<spring>` component, and to `springValue` when they need `realValue` / `realVelocity`.
- The internal function (still named `useSpring`, used by `<spring>` and tests) is untouched. The public export goes through a thin `useSpringPublic` wrapper that's re-exported as `useSpring` from `src/vue/index.ts`.
- Adds a deprecation banner to the `useSpring` section in `README.md` and `README.ja.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked `useSpring` composable as deprecated; users should prefer the `<spring>` component instead.
  * For access to real values and velocity, use `springValue` instead.

* **Deprecation**
  * Added one-time console warning when using `useSpring` to notify of deprecation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ktsn/css-spring-animation/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->