### PR TITLE
ci: publish to npm via GitHub Actions on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Generate type declarations
+        run: pnpm dts
+
+      - name: Build
+        run: pnpm run -r build
+
+      - name: Copy UMD files
+        run: |
+          cp packages/core/dist/css-spring-animation-core.umd.cjs packages/core/dist/css-spring-animation-core.umd.js
+          cp packages/vue/dist/css-spring-animation-vue.umd.cjs packages/vue/dist/css-spring-animation-vue.umd.js
+
+      - name: Copy README files
+        run: |
+          cp README.md packages/vue/README.md
+          cp README.ja.md packages/vue/README.ja.md
+
+      - name: Publish to npm
+        run: pnpm -r publish --access public --provenance --no-git-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,27 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Test
-        run: pnpm test
-
-      - name: Generate type declarations
-        run: pnpm dts
-
       - name: Build
-        run: pnpm run -r build
-
-      - name: Copy UMD files
-        run: |
-          cp packages/core/dist/css-spring-animation-core.umd.cjs packages/core/dist/css-spring-animation-core.umd.js
-          cp packages/vue/dist/css-spring-animation-vue.umd.cjs packages/vue/dist/css-spring-animation-vue.umd.js
-
-      - name: Copy README files
-        run: |
-          cp README.md packages/vue/README.md
-          cp README.ja.md packages/vue/README.ja.md
+        run: ./scripts/build.sh
 
       - name: Publish to npm
         run: pnpm -r publish --access public --provenance --no-git-checks

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+pnpm run typecheck --run
+pnpm run test --run
+pnpm run dts
+pnpm run -r build
+cp packages/core/dist/css-spring-animation-core.umd.cjs packages/core/dist/css-spring-animation-core.umd.js
+cp packages/vue/dist/css-spring-animation-vue.umd.cjs packages/vue/dist/css-spring-animation-vue.umd.js

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,5 +29,3 @@ cp README.ja.md packages/vue/README.ja.md
 git add .
 git commit -m "v$1"
 git tag v$1
-
-pnpm -r publish --access public

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,12 +10,7 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-pnpm run typecheck --run
-pnpm run test --run
-pnpm run dts
-pnpm run -r build
-cp packages/core/dist/css-spring-animation-core.umd.cjs packages/core/dist/css-spring-animation-core.umd.js
-cp packages/vue/dist/css-spring-animation-vue.umd.cjs packages/vue/dist/css-spring-animation-vue.umd.js
+./scripts/build.sh
 
 npm version $1 --git-tag-version false
 (cd packages/core; npm version $1 --git-tag-version false)
@@ -29,3 +24,5 @@ cp README.ja.md packages/vue/README.ja.md
 git add .
 git commit -m "v$1"
 git tag v$1
+
+git push --follow-tags


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that runs on `v*` tag push and publishes `@css-spring-animation/core` and `@css-spring-animation/vue` to npm via OIDC trusted publishing (with provenance).
- Update `scripts/publish.sh` to stop after creating the commit and tag — the actual `pnpm publish` is now handled by CI.

## Release flow
1. Run `./scripts/publish.sh <version>` locally (bumps versions, regenerates `CHANGELOG.md`, commits, tags `v<version>`).
2. `git push --follow-tags`.
3. CI picks up the tag and publishes both packages to npm.

## Prerequisites
- Configure Trusted Publisher on npm for both packages, pointing to this repo's `release.yml`.