### PR TITLE
feat!: remove deprecated useSpring composable and relocating option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,7 +57,7 @@ const moved = ref(false)
 
 ## `disabled` と `inferVelocity`
 
-`<spring>` コンポーネントと `useSpring` コンポーザブルは `disabled` オプションを指定できます。`disabled` が `true` の間は実行中のアニメーションが停止し、以降のスタイル変更ではアニメーションを発火させずに値だけを即座に更新します。
+`<spring>` コンポーネントは `disabled` オプションを指定できます。`disabled` が `true` の間は実行中のアニメーションが停止し、以降のスタイル変更ではアニメーションを発火させずに値だけを即座に更新します。
 
 アニメーションが再開する際の初速の扱いは、`inferVelocity` で切り替えられます。
 
@@ -205,7 +205,6 @@ requestAnimationFrame(() => {
 - `duration`
 - `disabled`
 - `inferVelocity`
-- `relocating` （deprecated — `disabled` と `inferVelocity: false` を使用してください）
 
 **イベント**
 
@@ -361,88 +360,6 @@ const list = ref([
     </li>
   </SpringTransitionGroup>
 </template>
-```
-
-### `useSpring` composable
-
-> **非推奨**。代わりに [`<spring>` コンポーネント](#spring-コンポーネント) を使用してください。`realValue` / `realVelocity` が必要な場合は [`springValue`](#springvalueinitial) を使用してください。
-
-スプリングアニメーションを適用した style オブジェクトを返す composable 関数です。また、現在のスタイル中の数値の実際の値と、速度も返します。これらは、スタイルオブジェクトと同じ形式のオブジェクトで、値が数値の配列になっています。
-
-第一引数はアニメーションさせるスタイルを返す関数、または ref です。第二引数はオプションオブジェクトです。これも関数、または ref にすることができます。
-
-オプションオブジェクトには以下のプロパティを指定できます。
-
-- `bounce`
-- `duration`
-- `disabled`
-- `inferVelocity`
-- `relocating` （deprecated — `disabled` と `inferVelocity: false` を使用してください）
-
-`<spring>` コンポーネントでは実装できない複雑なユースケースで使うことを想定しています。
-
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSpring } from '@css-spring-animation/vue'
-
-const position = ref(0)
-
-const { style, realValue, realVelocity } = useSpring(
-  () => {
-    return {
-      translate: `${position.value}px`,
-    }
-  },
-  () => {
-    return {
-      duration: 600,
-      bounce: 0.3,
-    }
-  },
-)
-</script>
-
-<template>
-  <div :style="style"></div>
-  <ul>
-    <li>realValue: {{ realValue.translate[0] }}</li>
-    <li>realVelocity: {{ realVelocity.translate[0] }}</li>
-  </ul>
-</template>
-```
-
-`useSpring` が返す値には、現在のアニメーションが完了、もしくは、settle するまで待つ `onFinishCurrent`、`onSettleCurrent` 関数があります。この関数には、進行中のアニメーションが完了・settle したときに呼ばれるコールバック関数を登録できます。
-
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSpring } from '@css-spring-animation/vue'
-
-const position = ref(0)
-
-const { style, onFinishCurrent } = useSpring(() => {
-  return {
-    translate: `${position.value}px`,
-  }
-})
-
-function move() {
-  // 100px まで移動
-  position.value = 100
-
-  // 上記の position の更新によってトリガーされたアニメーションが完了（duration が経過）するまで待つ
-  onFinishCurrent(() => {
-    // 0px まで移動
-    position.value = 0
-  })
-
-  // 上記の position の更新によってトリガーされたアニメーションが settle（見た目が停止）するまで待つ
-  onSettleCurrent(() => {
-    console.log('settled')
-  })
-}
-</script>
 ```
 
 ### `springValue(initial)`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Perceptive duration (ms) of an animation. The default value is 1000.
 
 ## `disabled` and `inferVelocity`
 
-`<spring>` component and `useSpring` composable accept a `disabled` option. While `disabled` is `true`, ongoing animation is stopped and further style changes update the value immediately without triggering a new animation.
+`<spring>` component accepts a `disabled` option. While `disabled` is `true`, ongoing animation is stopped and further style changes update the value immediately without triggering a new animation.
 
 When animation later resumes, the spring's initial velocity comes from one of two sources, controlled by `inferVelocity`:
 
@@ -205,7 +205,6 @@ It renders a native HTML element as same tag name as the property name (e.g. `<s
 - `duration`
 - `disabled`
 - `inferVelocity`
-- `relocating` (deprecated — use `disabled` + `inferVelocity: false`)
 
 **Events**
 
@@ -361,88 +360,6 @@ const list = ref([
     </li>
   </SpringTransitionGroup>
 </template>
-```
-
-### `useSpring` composable
-
-> **Deprecated.** Prefer the [`<spring>` component](#spring-component). If you need access to `realValue` / `realVelocity`, use [`springValue`](#springvalueinitial) instead.
-
-A composable function to generate spring animation style. It also returns the real value and velocity of the corresponding number in the style value. They are as same shape as the style value except that its values are the array of numbers.
-
-The first argument is a function or ref that returns the style object to be animated. The second argument is an options object. It also can be a function or ref that returns the options.
-
-The options object expectes the following properties:
-
-- `bounce`
-- `duration`
-- `disabled`
-- `inferVelocity`
-- `relocating` (deprecated — use `disabled` + `inferVelocity: false`)
-
-It is expected to be used in a complex situation that `<spring>` component is not suitable to be used.
-
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSpring } from '@css-spring-animation/vue'
-
-const position = ref(0)
-
-const { style, realValue, realVelocity } = useSpring(
-  () => {
-    return {
-      translate: `${position.value}px`,
-    }
-  },
-  () => {
-    return {
-      duration: 600,
-      bounce: 0.3,
-    }
-  },
-)
-</script>
-
-<template>
-  <div :style="style"></div>
-  <ul>
-    <li>realValue: {{ realValue.translate[0] }}</li>
-    <li>realVelocity: {{ realVelocity.translate[0] }}</li>
-  </ul>
-</template>
-```
-
-`useSpring` provides `onFinishCurrent` and `onSettleCurrent` functions for waiting until the current animation is finished or settled. You can register a callback function that will be called when an ongoing animation is finished/settled.
-
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSpring } from '@css-spring-animation/vue'
-
-const position = ref(0)
-
-const { style, onFinishCurrent } = useSpring(() => {
-  return {
-    translate: `${position.value}px`,
-  }
-})
-
-function move() {
-  // Move to 100px
-  position.value = 100
-
-  // Wait for the animation is finished (duration passed) triggered by the above position update
-  onFinishCurrent(() => {
-    // Move to 0px
-    position.value = 0
-  })
-
-  // Wait for the animation is settled (visually stopped) triggered by the above position update
-  onSettleCurrent(() => {
-    console.log('settled')
-  })
-}
-</script>
 ```
 
 ### `springValue(initial)`

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -1,7 +1,6 @@
 export { spring } from './spring-element'
 export { default as SpringTransition } from './SpringTransition'
 export { default as SpringTransitionGroup } from './SpringTransitionGroup'
-export { useSpringPublic as useSpring } from './use-spring'
 export { springValue, springComputed } from './spring-value'
 export { springDirectives } from './directives'
 

--- a/src/vue/spring-element.ts
+++ b/src/vue/spring-element.ts
@@ -16,8 +16,6 @@ const createSpringElement = (tagName: string) => {
       duration: Number,
       disabled: Boolean,
       inferVelocity: { type: Boolean, default: true },
-      /** @deprecated Use `disabled` with `:infer-velocity="false"` instead. */
-      relocating: Boolean,
     },
 
     emits: {
@@ -34,7 +32,6 @@ const createSpringElement = (tagName: string) => {
             duration: props.duration,
             disabled: props.disabled,
             inferVelocity: props.inferVelocity,
-            relocating: props.relocating,
           }
         },
       )

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -9,7 +9,6 @@ import {
   toRef,
   toValue,
   watch,
-  watchEffect,
 } from 'vue'
 import { AnimateValue, SpringOptions, createAnimateController } from '../core'
 import { isSameStyle } from '../core/controller'
@@ -20,8 +19,6 @@ type RefOrGetter<T> = Ref<T> | (() => T)
 export interface UseSpringOptions extends SpringOptions {
   disabled?: boolean
   inferVelocity?: boolean
-  /** @deprecated Use `disabled: true` with `inferVelocity: false` instead. */
-  relocating?: boolean
 }
 
 type SpringStyleRef = Readonly<Ref<Record<string, string>>>
@@ -34,25 +31,6 @@ export interface UseSpringResult<Values extends Record<string, number[]>> {
   onSettle: (fn: (data: { stopped: boolean }) => void) => void
   onFinishCurrent: (fn: (data: { stopped: boolean }) => void) => void
   onSettleCurrent: (fn: (data: { stopped: boolean }) => void) => void
-}
-
-let warnedUseSpring = false
-
-/**
- * @deprecated Use the `<spring>` component instead. If you need `realValue` or
- * `realVelocity`, use `springValue`.
- */
-export function useSpringPublic<Style extends Record<string, AnimateValue>>(
-  styleMapper: RefOrGetter<Style>,
-  options?: MaybeRefOrGetter<UseSpringOptions>,
-): UseSpringResult<Record<keyof Style, number[]>> {
-  if (!warnedUseSpring) {
-    warnedUseSpring = true
-    console.warn(
-      '[css-spring-animation] `useSpring` is deprecated. Use the `<spring>` component instead. If you need `realValue` or `realVelocity`, use `springValue`.',
-    )
-  }
-  return useSpring(styleMapper, options)
 }
 
 export function useSpring<Style extends Record<string, AnimateValue>>(
@@ -92,28 +70,9 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
 
   const optionsRef = computed(() => toValue(options) ?? {})
 
-  const disabled = computed(
-    () =>
-      (optionsRef.value.disabled ?? false) ||
-      (optionsRef.value.relocating ?? false),
-  )
+  const disabled = computed(() => optionsRef.value.disabled ?? false)
 
-  const inferVelocity = computed(() => {
-    if (optionsRef.value.relocating) {
-      return false
-    }
-    return optionsRef.value.inferVelocity ?? true
-  })
-
-  let warnedRelocating = false
-  watchEffect(() => {
-    if (optionsRef.value.relocating && !warnedRelocating) {
-      warnedRelocating = true
-      console.warn(
-        '[css-spring-animation] `relocating` is deprecated. Use `disabled: true` with `inferVelocity: false` instead.',
-      )
-    }
-  })
+  const inferVelocity = computed(() => optionsRef.value.inferVelocity ?? true)
 
   const style = ref<Record<string, string>>({})
 

--- a/test/vue/spring-element.test.ts
+++ b/test/vue/spring-element.test.ts
@@ -89,7 +89,6 @@ describe('Spring Element', () => {
       duration: 800,
       disabled: false,
       inferVelocity: true,
-      relocating: false,
     })
     expect(mockController.setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
@@ -111,40 +110,6 @@ describe('Spring Element', () => {
         const springStyle = ref({ opacity: 1 })
         return {
           springStyle,
-        }
-      },
-    })
-    const vm: any = app.mount(root)
-    expect(vm.$el.style.opacity).toBe('1')
-
-    vm.springStyle.opacity = 0
-    await nextTick()
-    expect(mockController.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
-    expect(vm.$el.style.opacity).toBe('0')
-  })
-
-  test('disable animation when relocating prop is true', async () => {
-    const root = document.createElement('div')
-    const app = createApp({
-      template: `
-        <springp :spring-style="springStyle" :relocating="relocating">
-          Hello
-        </springp>
-      `,
-
-      components: {
-        springp: spring.p!,
-      },
-
-      setup() {
-        const springStyle = ref({ opacity: 1 })
-        const relocating = ref(true)
-        return {
-          springStyle,
-          relocating,
         }
       },
     })
@@ -268,28 +233,6 @@ describe('Spring Element', () => {
           :spring-style="springStyle"
           :duration="10"
           disabled
-          @spring-finish="onFinish"
-          @spring-settle="onSettle"
-        />
-      `,
-    )
-
-    vm.springStyle = { width: '20px' }
-    await nextTick()
-    await nextTick()
-    await waitForCurrentCycleSettled()
-
-    expect(finish).not.toHaveBeenCalled()
-    expect(settle).not.toHaveBeenCalled()
-  })
-
-  test('do not emit when relocating', async () => {
-    const { vm, finish, settle } = mountWithEvents(
-      `
-        <springp
-          :spring-style="springStyle"
-          :duration="10"
-          relocating
           @spring-finish="onFinish"
           @spring-settle="onSettle"
         />

--- a/test/vue/use-spring.test.ts
+++ b/test/vue/use-spring.test.ts
@@ -33,28 +33,6 @@ describe('useSpring', () => {
     expect(style.value.width).toBe('20')
   })
 
-  test('update style value immediately when relocating', async () => {
-    const value = ref(10)
-
-    const { style } = useSpring(
-      () => {
-        return {
-          width: value.value,
-        }
-      },
-      () => {
-        return {
-          relocating: true,
-        }
-      },
-    )
-
-    expect(style.value.width).toBe('10')
-    value.value = 20
-    await nextTick()
-    expect(style.value.width).toBe('20')
-  })
-
   test('return real values', async () => {
     const value = ref(10)
 
@@ -84,26 +62,6 @@ describe('useSpring', () => {
       }),
       {
         disabled: true,
-      },
-    )
-
-    expect(realValue.value.width).toEqual([10])
-    value.value = 20
-    await nextTick()
-    expect(realValue.value.width).toEqual([20])
-  })
-
-  test('return input value as real value when relocating', async () => {
-    const value = ref(10)
-
-    const { realValue } = useSpring(
-      () => ({
-        width: value.value,
-      }),
-      () => {
-        return {
-          relocating: true,
-        }
       },
     )
 
@@ -174,34 +132,6 @@ describe('useSpring', () => {
     expect(realVelocity.value.width).toEqual([0])
     await nextTick()
     expect(realVelocity.value.width).not.toEqual([0])
-  })
-
-  test('keep last real velocity when relocating', async () => {
-    const value = ref(10)
-    const relocating = ref(false)
-
-    const { realVelocity } = useSpring(
-      () => ({
-        width: value.value,
-      }),
-      () => ({
-        duration: 10,
-        relocating: relocating.value,
-      }),
-    )
-    expect(realVelocity.value.width).toEqual([0])
-
-    // Animate to negative direction
-    value.value = 0
-    await nextTick()
-
-    // Relocating to positive direction
-    relocating.value = true
-    value.value = 30
-    await nextTick()
-
-    // Velocity should be kept as negative
-    expect(realVelocity.value.width[0]).toBeLessThan(0)
   })
 
   test('keep last real velocity when disabled with inferVelocity=false', async () => {


### PR DESCRIPTION
## Summary

- Removes the public `useSpring` composable export. Use `<spring>` instead, or `springValue` for `realValue` / `realVelocity` access.
- Removes the `relocating` option from `<spring>` and `useSpring`. Use `disabled: true` with `inferVelocity: false` instead.
- Updates README (English & Japanese) to drop the `useSpring` section and `relocating` references.
- Drops the corresponding tests.

The internal `useSpring` helper is kept since `<spring>` still uses it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated `relocating` option from Vue spring components and composables.
  * Removed the `useSpring` composable from public exports.
  * Updated documentation to reflect API changes; users previously relying on `relocating` should use `disabled` with `inferVelocity: false` instead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ktsn/css-spring-animation/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->