### PR TITLE
feat: expose animate function as public api

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -499,3 +499,56 @@ function animate(now: number) {
 
 requestAnimationFrame(animate)
 ```
+
+### `animate(target, [from, to], options)`
+
+DOM 要素のスタイルプロパティをスプリング物理で命令的にアニメーションさせる低レベル関数です。Vue コンポーネントの外でスプリングアニメーションを使いたい時に利用します。
+
+**パラメータ**
+
+- `target`: アニメーション対象の `HTMLElement` または `SVGElement`
+- `fromTo`: スタイルオブジェクトの `[from, to]` タプル。各スタイルオブジェクトは CSS プロパティ名に対して `number`、`string`、または `springValue` / `springComputed` を `sv` で埋め込んだ値をマップします。
+- `options`: スプリングオプション（省略可）
+  - `duration`: ミリ秒単位の時間（デフォルト: 1000）
+  - `bounce`: バウンス度合い（-1 から 1、デフォルト: 0）
+
+**戻り値**
+
+以下のプロパティを持つ `AnimateContext` を返します。
+
+- `finished` (boolean): `duration` 経過時にアニメーションが視覚的に完了すると `true` になります。
+- `settled` (boolean): スプリングが完全に減衰すると `true` になります。
+- `finishingPromise` (`Promise<void>`): `finished` が `true` になった時に resolve されます。
+- `settlingPromise` (`Promise<void>`): `settled` が `true` になった時に resolve されます。
+- `stop()`: アニメーションを即座にキャンセルし、現在の値を確定します。
+- `stoppedDuration` (`number | undefined`): `stop()` が呼ばれた時点の経過時間。停止されていない場合は `undefined`。
+
+```ts
+import { animate } from '@ktsn/spring'
+
+const el = document.querySelector('.rectangle') as HTMLElement
+
+const ctx = animate(
+  el,
+  [{ translate: '0px 0px' }, { translate: '300px 300px' }],
+  { duration: 1000, bounce: 0 },
+)
+
+ctx.settlingPromise.then(() => {
+  // スプリングが完全に減衰した
+})
+```
+
+`from` または `to` のスロットを `sv` で `springValue` から構築すると、そのスプリング値の `current()` と `velocity()` がアニメーション実行中の現在値・速度を返すようになります。
+
+```ts
+import { animate, springValue, sv } from '@ktsn/spring'
+
+const x = springValue(0)
+
+animate(el, [{ translate: sv`${x}px` }, { translate: '100px' }], {
+  duration: 600,
+})
+
+// x.current() / x.velocity() でアニメーション中の値・速度が読める
+```

--- a/README.md
+++ b/README.md
@@ -507,3 +507,56 @@ function animate(now: number) {
 
 requestAnimationFrame(animate)
 ```
+
+### `animate(target, [from, to], options)`
+
+A low-level function that imperatively animates style properties on a DOM element with spring physics. Useful when you want spring animation outside of Vue components.
+
+**Parameters**
+
+- `target`: An `HTMLElement` or `SVGElement` to animate.
+- `fromTo`: A `[from, to]` tuple of style objects. Each style object maps CSS property names to a `number`, a `string`, or a value built from `sv` over `springValue` / `springComputed`.
+- `options`: Spring options (optional)
+  - `duration`: Duration in milliseconds (default: 1000)
+  - `bounce`: Bounciness (-1 to 1, default: 0)
+
+**Return value**
+
+Returns an `AnimateContext` with:
+
+- `finished` (boolean): becomes `true` once the animation visually completes (after `duration` ms).
+- `settled` (boolean): becomes `true` once the spring has fully decayed.
+- `finishingPromise` (`Promise<void>`): resolves when `finished` flips to `true`.
+- `settlingPromise` (`Promise<void>`): resolves when `settled` flips to `true`.
+- `stop()`: cancels the animation immediately and commits the current value.
+- `stoppedDuration` (`number | undefined`): the elapsed time at the moment `stop()` was called, or `undefined` if not stopped.
+
+```ts
+import { animate } from '@ktsn/spring'
+
+const el = document.querySelector('.rectangle') as HTMLElement
+
+const ctx = animate(
+  el,
+  [{ translate: '0px 0px' }, { translate: '300px 300px' }],
+  { duration: 1000, bounce: 0 },
+)
+
+ctx.settlingPromise.then(() => {
+  // the spring has fully settled
+})
+```
+
+When a slot in `from` or `to` is built from `springValue` via `sv`, the spring value's `current()` and `velocity()` reflect the live animation while it runs:
+
+```ts
+import { animate, springValue, sv } from '@ktsn/spring'
+
+const x = springValue(0)
+
+animate(el, [{ translate: sv`${x}px` }, { translate: '100px' }], {
+  duration: 600,
+})
+
+// x.current() / x.velocity() now reflect the live animation
+```

--- a/demo/plain/index.ts
+++ b/demo/plain/index.ts
@@ -1,15 +1,12 @@
 import { animate } from '../../src/core'
 
-const demo = document.getElementById('demo')!
+const demo = document.getElementById('demo') as HTMLElement
 let ctx: ReturnType<typeof animate> | undefined
 
 setInterval(() => {
-  animate(
-    (style) => {
-      Object.entries(style).forEach(([k, v]) => {
-        demo.style.setProperty(k, v)
-      })
-    },
+  ctx?.stop()
+  ctx = animate(
+    demo,
     [{ translate: `0px 0px` }, { translate: `300px 300px` }],
     {
       duration: 1000,

--- a/demo/visualizer/App.vue
+++ b/demo/visualizer/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CSSProperties, ref, shallowRef, watchEffect } from 'vue'
+import { ref, shallowRef, watchEffect } from 'vue'
 import {
   AnimateContext,
   animate,
@@ -25,8 +25,7 @@ const parameters = ref({
 })
 
 const canvas = shallowRef<HTMLCanvasElement>()
-
-const style = ref<CSSProperties>({})
+const previewBall = shallowRef<HTMLDivElement>()
 
 function renderLines(
   ctx: CanvasRenderingContext2D,
@@ -223,12 +222,12 @@ watchEffect(() => {
 
     ctx?.stop()
     animateTimer = requestAnimationFrame(() => {
+      const ball = previewBall.value
+      if (!ball) return
       const fromSv = springValue(from)
       fromSv.setVelocity(velocity)
       ctx = animate(
-        (_style) => {
-          style.value = _style
-        },
+        ball,
         [{ translate: sv`${fromSv}px` }, { translate: `${to}px` }],
         {
           bounce,
@@ -260,7 +259,7 @@ watchEffect(() => {
   <div class="wrapper">
     <div class="preview">
       <div class="preview-behavior">
-        <div class="preview-ball" :style="style"></div>
+        <div class="preview-ball" ref="previewBall"></div>
       </div>
 
       <div class="preview-graph">

--- a/src/core/animate.ts
+++ b/src/core/animate.ts
@@ -3,12 +3,13 @@ import {
   generateSpringExpressionStyle,
   createSpring,
   springSettlingDuration,
+  springEasingFn,
   Spring,
-  springCSSInternal,
 } from './spring'
 import {
   isCssLinearTimingFunctionSupported,
   isCssMathAnimationSupported,
+  isWebAnimationsApiSupported,
   mapValues,
   zip,
 } from './utils'
@@ -25,6 +26,8 @@ import {
   liftToSpringStyle,
   snapshotSpringStyle,
 } from './spring-value'
+
+export type AnimationTarget = HTMLElement | SVGElement
 
 export type AnimateValue = number | string | SpringStyleValue
 
@@ -45,7 +48,7 @@ export interface AnimateContext {
 }
 
 export function animate<Style extends Record<string, AnimateValue>>(
-  set: (style: Record<string, string>) => void,
+  target: AnimationTarget,
   fromTo: [Style, Style],
   options: SpringOptions = {},
 ): AnimateContext {
@@ -118,13 +121,16 @@ export function animate<Style extends Record<string, AnimateValue>>(
 
   const startTime = performance.now()
 
+  const animations: Animation[] = []
+
   const ctx = createContext({
+    target,
     slots,
     fromTo: parsedFromTo,
     startTime,
     duration,
     settlingDuration,
-    set,
+    animations,
   })
 
   // Attach animation info to every slot's SpringComputed.
@@ -149,33 +155,40 @@ export function animate<Style extends Record<string, AnimateValue>>(
     })
   }
 
+  const waapi = isWebAnimationsApiSupported()
+
   if (
+    waapi &&
     isCssLinearTimingFunctionSupported() &&
     canUseLinearTimingFunction(parsedFromTo, slotVelocities)
   ) {
-    animateWithLinearTimingFunction({
-      spring,
-      fromTo: parsedFromTo,
-      inputValues,
-      settlingDuration,
-      set,
-    })
-  } else if (isCssMathAnimationSupported()) {
-    animateWithCssCustomPropertyMath({
-      spring,
-      fromTo: parsedFromTo,
-      inputValues,
-      duration,
-      settlingDuration,
-      set,
-    })
+    animations.push(
+      ...animateWithPerPropertyEasing({
+        target,
+        spring,
+        fromTo: parsedFromTo,
+        inputValues,
+        settlingDuration,
+      }),
+    )
+  } else if (waapi && isCssMathAnimationSupported()) {
+    animations.push(
+      ...animateWithProxyTimeVariable({
+        target,
+        spring,
+        fromTo: parsedFromTo,
+        inputValues,
+        duration,
+        settlingDuration,
+      }),
+    )
   } else {
-    // Graceful degradation
+    // Graceful degradation for environments without WAAPI / linear() / CSS math.
     animateWithRaf({
+      target,
       fromTo: parsedFromTo,
       slots,
-      context: ctx,
-      set,
+      ctx,
     })
   }
 
@@ -234,167 +247,142 @@ function canUseLinearTimingFunction(
   })
 }
 
-function animateWithLinearTimingFunction({
+function animateWithPerPropertyEasing({
+  target,
   spring,
   fromTo,
   inputValues,
   settlingDuration,
-  set,
 }: {
+  target: AnimationTarget
   spring: Spring
   fromTo: Record<string, [ParsedStyleValue, ParsedStyleValue]>
   inputValues: Record<string, InputValueGroup[]>
   settlingDuration: number
-  set: (style: Record<string, string>) => void
-}): void {
-  const fromStyle = mapValues(fromTo, ([from, to]) => {
-    // Skip animation if the value is not consistent
+}): Animation[] {
+  const animations: Animation[] = []
+
+  for (const key of Object.keys(fromTo)) {
+    const [from, to] = fromTo[key]!
+
     if (from.values.length !== to.values.length) {
-      return interpolateParsedStyle(to, to.values)
+      // Skip animation if the value is not consistent
+      writeStyle(target, key, interpolateParsedStyle(to, to.values))
+      continue
     }
 
-    return interpolateParsedStyle(from, from.values)
-  })
+    const completedTo = completeParsedStyleUnit(to, from)
+    const fromStr = interpolateParsedStyle(from, from.values)
+    const toStr = interpolateParsedStyle(completedTo, completedTo.values)
 
-  set({
-    ...fromStyle,
-    transition: 'none',
-  })
+    const values = inputValues[key]!
+    const normalizedVelocity = values.reduce<number | undefined>(
+      (acc, { from, to, velocity }) => {
+        if (acc !== undefined) {
+          return acc
+        }
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const toStyle = mapValues(fromTo, ([from, to]) => {
-        const completedTo = completeParsedStyleUnit(to, from)
-        return interpolateParsedStyle(completedTo, completedTo.values)
-      })
+        if (from === to) {
+          return undefined
+        }
 
-      const transitionValues = mapValues(inputValues, (values) => {
-        const normalizedVelocity = values.reduce<number | undefined>(
-          (acc, { from, to, velocity }) => {
-            if (acc !== undefined) {
-              return acc
-            }
+        return velocity / (to - from)
+      },
+      undefined,
+    )
 
-            if (from === to) {
-              return undefined
-            }
-
-            return velocity / (to - from)
-          },
-          undefined,
-        )
-
-        return springCSSInternal({
-          spring,
-          settlingDuration,
-          normalizedVelocity: normalizedVelocity ?? 0,
-        })
-      })
-
-      const transition = Object.entries(transitionValues)
-        .map(([key, transitionValue]) => {
-          return `${key} ${transitionValue}`
-        })
-        .join(',')
-
-      set({
-        ...toStyle,
-        transition,
-      })
+    const easing = springEasingFn({
+      spring,
+      settlingDuration,
+      normalizedVelocity: normalizedVelocity ?? 0,
     })
-  })
+
+    const a = target.animate(
+      [keyframeFor(key, fromStr), keyframeFor(key, toStr)],
+      { duration: settlingDuration, easing, fill: 'forwards' },
+    )
+    animations.push(a)
+  }
+
+  return animations
 }
 
-function animateWithCssCustomPropertyMath({
+function animateWithProxyTimeVariable({
+  target,
   spring,
   fromTo,
   inputValues,
   duration,
   settlingDuration,
-  set,
 }: {
+  target: AnimationTarget
   spring: Spring
   fromTo: Record<string, [ParsedStyleValue, ParsedStyleValue]>
   inputValues: Record<string, InputValueGroup[]>
   duration: number
   settlingDuration: number
-  set: (style: Record<string, string>) => void
-}): void {
+}): Animation[] {
   registerPropertyIfNeeded()
 
-  const style = mapValues(fromTo, ([from, to], key) => {
-    // Skip animation if the value is not consistent
+  for (const key of Object.keys(fromTo)) {
+    const [from, to] = fromTo[key]!
+
     if (from.values.length !== to.values.length) {
-      return interpolateParsedStyle(to, to.values)
+      writeStyle(target, key, interpolateParsedStyle(to, to.values))
+      continue
     }
 
     const values = inputValues[key]!
-
-    const style = values.map(({ from, to, velocity }) => {
-      return generateSpringExpressionStyle(spring, {
+    const exprValues = values.map(({ from, to, velocity }) =>
+      generateSpringExpressionStyle(spring, {
         from,
         to,
         initialVelocity: velocity,
-      })
-    })
-
+      }),
+    )
     const completedTo = completeParsedStyleUnit(to, from)
-    return interpolateParsedStyle(completedTo, style)
-  })
+    writeStyle(target, key, interpolateParsedStyle(completedTo, exprValues))
+  }
 
-  set({
-    ...style,
-    transition: 'none',
-    [t]: '0',
-  })
+  target.style.setProperty(t, '0')
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      set({
-        ...style,
-        transition: `${t} ${settlingDuration}ms linear`,
-        [t]: String(settlingDuration / duration),
-      })
-    })
-  })
+  const a = target.animate(
+    [{ [t]: '0' }, { [t]: String(settlingDuration / duration) }],
+    { duration: settlingDuration, easing: 'linear', fill: 'forwards' },
+  )
+  return [a]
 }
 
 function animateWithRaf({
+  target,
   fromTo,
   slots,
-  context,
-  set,
+  ctx,
 }: {
+  target: AnimationTarget
   fromTo: Record<string, [ParsedStyleValue, ParsedStyleValue]>
   slots: Record<string, SpringComputed[]>
-  context: AnimateContext
-  set: (style: Record<string, string>) => void
+  ctx: AnimateContext
 }): void {
   function render(): void {
-    if (context.settled) {
+    if (ctx.settled) {
       return
     }
 
-    const style = mapValues(fromTo, ([from, to], key) => {
-      // Skip animation if the value is not consistent
-      if (from.values.length !== to.values.length) {
-        return interpolateParsedStyle(to, to.values)
-      }
-
+    for (const key in fromTo) {
+      const [from, to] = fromTo[key]!
       const keySlots = slots[key]
-      if (!keySlots) {
-        return ''
+      if (!keySlots) continue
+
+      if (from.values.length !== to.values.length) {
+        writeStyle(target, key, interpolateParsedStyle(to, to.values))
+        continue
       }
 
-      const realValue = keySlots.map((s) => s.current())
       const completedTo = completeParsedStyleUnit(to, from)
-      return interpolateParsedStyle(completedTo, realValue)
-    })
-
-    set({
-      ...style,
-      transition: 'none',
-    })
+      const realValue = keySlots.map((s) => s.current())
+      writeStyle(target, key, interpolateParsedStyle(completedTo, realValue))
+    }
 
     requestAnimationFrame(render)
   }
@@ -405,19 +393,21 @@ function animateWithRaf({
 function createContext<
   FromTo extends Record<string, [ParsedStyleValue, ParsedStyleValue]>,
 >({
+  target,
   slots,
   fromTo,
   startTime,
   duration,
   settlingDuration,
-  set,
+  animations,
 }: {
+  target: AnimationTarget
   slots: Record<keyof FromTo, SpringComputed[]>
   fromTo: FromTo
   startTime: number
   duration: number
   settlingDuration: number
-  set: (style: Record<string, string>) => void
+  animations: Animation[]
 }): AnimateContext {
   const forceResolve: { fn: (() => void)[] } = { fn: [] }
 
@@ -427,27 +417,32 @@ function createContext<
     }
     ctx.finished = ctx.settled = true
     ctx.stoppedDuration = performance.now() - startTime
+    cancelAnimations()
     setRealStyle()
     forceResolve.fn.forEach((fn) => fn())
   }
 
-  function setRealStyle() {
-    const style = mapValues(fromTo, ([from, to], key) => {
-      const keySlots = slots[key]
-      if (!keySlots) {
-        return ''
+  function cancelAnimations() {
+    for (const a of animations) {
+      try {
+        a.cancel()
+      } catch {
+        // ignore — already cancelled or implementation-specific quirk
       }
+    }
+  }
+
+  function setRealStyle() {
+    for (const key in fromTo) {
+      const [from, to] = fromTo[key]!
+      const keySlots = slots[key]
+      if (!keySlots) continue
 
       const completedTo = completeParsedStyleUnit(to, from)
       const realValue = keySlots.map((s) => s.current())
-      return interpolateParsedStyle(completedTo, realValue)
-    })
-
-    set({
-      ...style,
-      transition: '',
-      [t]: '',
-    })
+      writeStyle(target, key, interpolateParsedStyle(completedTo, realValue))
+    }
+    target.style.removeProperty(t)
   }
 
   const ctx: AnimateContext = {
@@ -459,6 +454,7 @@ function createContext<
       ctx.finished = ctx.settled = true
 
       if (ctx.stoppedDuration === undefined) {
+        cancelAnimations()
         setRealStyle()
       }
     }),
@@ -471,4 +467,20 @@ function createContext<
   }
 
   return ctx
+}
+
+function keyframeFor(key: string, value: string): Keyframe {
+  return { [key]: value } as Keyframe
+}
+
+export function writeStyle(
+  target: AnimationTarget,
+  key: string,
+  value: string,
+): void {
+  if (key.startsWith('--')) {
+    target.style.setProperty(key, value)
+  } else {
+    target.style[key as any] = value
+  }
 }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -1,4 +1,11 @@
-import { AnimateContext, animate, AnimateValue, SpringOptions } from './animate'
+import {
+  AnimateContext,
+  AnimateValue,
+  AnimationTarget,
+  SpringOptions,
+  animate,
+  writeStyle,
+} from './animate'
 import {
   ParsedStyleValue,
   StyleValue,
@@ -37,6 +44,8 @@ export interface AnimationController<
 
   onFinishCurrent: (fn: (data: { stopped: boolean }) => void) => void
   onSettleCurrent: (fn: (data: { stopped: boolean }) => void) => void
+
+  dispose: () => void
 }
 
 interface ValueHistoryItem<Key extends PropertyKey> {
@@ -46,7 +55,7 @@ interface ValueHistoryItem<Key extends PropertyKey> {
 
 export function createAnimateController<
   Style extends Record<string, AnimateValue>,
->(set: (style: Record<string, string>) => void): AnimationController<Style> {
+>(target: AnimationTarget): AnimationController<Style> {
   /** Holding the snapshotted form of the most recently committed style */
   let style: Record<keyof Style, ParsedStyleValue> | undefined
 
@@ -96,6 +105,19 @@ export function createAnimateController<
     return mapValues(next, (value) => new Array(value.values.length).fill(0))
   }
 
+  function commitStaticStyle(
+    parsed: Record<keyof Style, ParsedStyleValue>,
+  ): void {
+    for (const key in parsed) {
+      writeStyle(
+        target,
+        key,
+        interpolateParsedStyle(parsed[key], parsed[key].values),
+      )
+    }
+    target.style.removeProperty(t)
+  }
+
   function stop({ keepVelocity }: StopOptions = {}): void {
     keptVelocity =
       keepVelocity && liveSlots ? liveRealVelocity(liveSlots) : undefined
@@ -106,7 +128,7 @@ export function createAnimateController<
 
     if (style) {
       style = liveSlots ? updateValues(style, liveRealValue(liveSlots)) : style
-      ctx = createContext()
+      ctx = createPseudoContext()
     }
 
     valueHistory = []
@@ -129,7 +151,7 @@ export function createAnimateController<
     const parsedStyleSnap = mapValues(wrappedParsedStyle, snapshotSpringStyle)
 
     if (style && isSameStyle(style, parsedStyleSnap)) {
-      return ctx ?? createContext()
+      return ctx ?? createPseudoContext()
     }
 
     const newSlots = mapValues(wrappedParsedStyle, (p) => p.values)
@@ -153,12 +175,8 @@ export function createAnimateController<
         ctx.stop()
       }
       liveSlots = newSlots
-      ctx = createContext()
-      set({
-        ...stringifyStyle(style),
-        transition: '',
-        [t]: '',
-      })
+      ctx = createPseudoContext()
+      commitStaticStyle(style)
 
       if (!keptVelocity) {
         valueHistory.push({
@@ -192,7 +210,7 @@ export function createAnimateController<
     }
 
     ctx = animate<Record<keyof Style, AnimateValue>>(
-      set,
+      target,
       [fromStyle, wrappedParsedStyle],
       options,
     )
@@ -234,12 +252,24 @@ export function createAnimateController<
     })
   }
 
+  function dispose(): void {
+    if (ctx && !ctx.settled) {
+      ctx.stop()
+    }
+    ctx = undefined
+    style = undefined
+    liveSlots = undefined
+    keptVelocity = undefined
+    valueHistory = []
+  }
+
   return {
     stop,
     setStyle,
     setOptions,
     onFinishCurrent,
     onSettleCurrent,
+    dispose,
   }
 }
 
@@ -283,18 +313,10 @@ function updateValues<Style extends Record<string, ParsedStyleValue>>(
   }) as Style
 }
 
-function stringifyStyle<Style extends Record<string, ParsedStyleValue>>(
-  style: Style,
-): Record<keyof Style, string> {
-  return mapValues(style, (value) =>
-    interpolateParsedStyle(value, value.values),
-  )
-}
-
 /**
  * Create a pseudo context for the state when no animation is running.
  */
-function createContext(): AnimateContext {
+function createPseudoContext(): AnimateContext {
   return {
     finished: true,
     settled: true,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,10 @@
 export { animate } from './animate'
-export type { AnimateContext, AnimateValue, SpringOptions } from './animate'
+export type {
+  AnimateContext,
+  AnimateValue,
+  AnimationTarget,
+  SpringOptions,
+} from './animate'
 
 export { createAnimateController } from './controller'
 export type { AnimationController } from './controller'

--- a/src/core/spring.ts
+++ b/src/core/spring.ts
@@ -256,6 +256,20 @@ export function springCSSInternal(params: {
   settlingDuration: number
   normalizedVelocity: number
 }): string {
+  return `${params.settlingDuration}ms ${springEasingFn(params)}`
+}
+
+/**
+ * @private
+ *
+ * Returns just the `linear(...)` easing-function string usable as the
+ * `easing` option of the Web Animations API.
+ */
+export function springEasingFn(params: {
+  spring: Spring
+  settlingDuration: number
+  normalizedVelocity: number
+}): string {
   const { spring, settlingDuration, normalizedVelocity } = params
 
   // 60fps
@@ -272,7 +286,7 @@ export function springCSSInternal(params: {
     return value
   })
 
-  return `${settlingDuration}ms linear(${easingValues.join(',')})`
+  return `linear(${easingValues.join(',')})`
 }
 
 /**

--- a/src/core/spring.ts
+++ b/src/core/spring.ts
@@ -237,26 +237,13 @@ export function springCSS(duration: number, bounce: number = 0): string {
     initialVelocity: 0,
   })
 
-  return springCSSInternal({
+  const easing = springEasingFn({
     spring,
     settlingDuration,
     normalizedVelocity: 0,
   })
-}
 
-/**
- * @private
- *
- * Generate CSS transition string from animation-related values.
- * Only used internally.
- * @param params.normalizedVelocity initial velocity rebased to 0-1 range
- */
-export function springCSSInternal(params: {
-  spring: Spring
-  settlingDuration: number
-  normalizedVelocity: number
-}): string {
-  return `${params.settlingDuration}ms ${springEasingFn(params)}`
+  return `${settlingDuration}ms ${easing}`
 }
 
 /**

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -26,6 +26,13 @@ export function range(start: number, end: number): number[] {
   return result
 }
 
+export function isWebAnimationsApiSupported(): boolean {
+  return (
+    typeof Element !== 'undefined' &&
+    typeof Element.prototype.animate === 'function'
+  )
+}
+
 export function isCssLinearTimingFunctionSupported(): boolean {
   return (
     typeof CSS !== 'undefined' &&

--- a/src/vue/SpringTransition.ts
+++ b/src/vue/SpringTransition.ts
@@ -9,20 +9,6 @@ import {
 // sc = Spring Controller
 export const scKey = Symbol('SpringController')
 
-export function createStyleSetter(
-  el: HTMLElement,
-): (style: Record<string, string>) => void {
-  return (style) => {
-    for (const key in style) {
-      if (key.startsWith('--')) {
-        el.style.setProperty(key, style[key] ?? '')
-      } else {
-        el.style[key as any] = style[key] ?? ''
-      }
-    }
-  }
-}
-
 export function useTransitionHooks(
   props: Omit<SpringTransitionProps, 'mode'>,
   emit: (name: string, el: Element) => void,
@@ -60,7 +46,7 @@ export function useTransitionHooks(
   function onEnter(_el: Element, done: () => void): void {
     const el = _el as HTMLElementWithController
     if (!el[scKey]) {
-      el[scKey] = createAnimateController(createStyleSetter(el))
+      el[scKey] = createAnimateController(el)
 
       el[scKey].setStyle(
         {
@@ -90,7 +76,7 @@ export function useTransitionHooks(
   function onLeave(_el: Element, done: () => void): void {
     const el = _el as HTMLElementWithController
     if (!el[scKey]) {
-      el[scKey] = createAnimateController(createStyleSetter(el))
+      el[scKey] = createAnimateController(el)
       el[scKey].setStyle(props.springStyle, { animate: false })
 
       forceReflow()

--- a/src/vue/SpringTransitionGroup.ts
+++ b/src/vue/SpringTransitionGroup.ts
@@ -12,7 +12,6 @@ import {
 import {
   HTMLElementWithController,
   SpringTransitionProps,
-  createStyleSetter,
   scKey,
   springTransitionProps,
   useTransitionHooks,
@@ -167,7 +166,7 @@ const SpringTransitionGroup = defineComponent({
 
         const el = child.el as HTMLElementWithController
         if (!el[scKey]) {
-          el[scKey] = createAnimateController(createStyleSetter(el))
+          el[scKey] = createAnimateController(el)
         }
         const controller = el[scKey]
 

--- a/src/vue/directives.ts
+++ b/src/vue/directives.ts
@@ -48,15 +48,7 @@ function ensureController(
 ): AnimationController<Record<string, AnimateValue>> {
   let controller = el.__springController
   if (!controller) {
-    controller = createAnimateController((style) => {
-      for (const key in style) {
-        if (key.startsWith('--')) {
-          el.style.setProperty(key, style[key] ?? '')
-        } else {
-          el.style[key as any] = style[key] ?? ''
-        }
-      }
-    })
+    controller = createAnimateController(el)
     el.__springController = controller
   }
   return controller

--- a/src/vue/spring-element.ts
+++ b/src/vue/spring-element.ts
@@ -1,4 +1,4 @@
-import { PropType, defineComponent, h } from 'vue'
+import { PropType, defineComponent, h, ref } from 'vue'
 import { AnimateValue } from '../core'
 import { useSpring } from './use-spring'
 import { SpringStyleValue } from '../core/spring-value'
@@ -24,7 +24,10 @@ const createSpringElement = (tagName: string) => {
     },
 
     setup(props, { emit, slots }) {
-      const { style, onFinish, onSettle } = useSpring(
+      const elRef = ref<HTMLElement | null>(null)
+
+      const { onFinish, onSettle } = useSpring(
+        elRef,
         () => props.springStyle,
         () => {
           return {
@@ -49,7 +52,7 @@ const createSpringElement = (tagName: string) => {
       })
 
       return () => {
-        return h(tagName, { style: style.value }, slots.default?.())
+        return h(tagName, { ref: elRef }, slots.default?.())
       }
     },
   })

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -3,12 +3,17 @@ import {
   Ref,
   computed,
   nextTick,
-  readonly,
-  ref,
+  onScopeDispose,
   toValue,
   watch,
 } from 'vue'
-import { AnimateValue, SpringOptions, createAnimateController } from '../core'
+import {
+  AnimateValue,
+  AnimationController,
+  AnimationTarget,
+  SpringOptions,
+  createAnimateController,
+} from '../core'
 import { isSameStyle } from '../core/controller'
 import { interpolateParsedStyle } from '../core/style'
 
@@ -19,10 +24,7 @@ export interface UseSpringOptions extends SpringOptions {
   inferVelocity?: boolean
 }
 
-type SpringStyleRef = Readonly<Ref<Record<string, string>>>
-
 export interface UseSpringResult {
-  style: SpringStyleRef
   onFinish: (fn: (data: { stopped: boolean }) => void) => void
   onSettle: (fn: (data: { stopped: boolean }) => void) => void
   onFinishCurrent: (fn: (data: { stopped: boolean }) => void) => void
@@ -30,6 +32,7 @@ export interface UseSpringResult {
 }
 
 export function useSpring<Style extends Record<string, AnimateValue>>(
+  element: MaybeRefOrGetter<AnimationTarget | null | undefined>,
   styleMapper: RefOrGetter<Style>,
   options?: MaybeRefOrGetter<UseSpringOptions>,
 ): UseSpringResult {
@@ -70,15 +73,39 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
 
   const inferVelocity = computed(() => optionsRef.value.inferVelocity ?? true)
 
-  const style = ref<Record<string, string>>({})
+  let controller:
+    | AnimationController<Record<keyof Style, AnimateValue>>
+    | undefined
 
-  const controller = createAnimateController<Record<keyof Style, AnimateValue>>(
-    (_style) => {
-      style.value = _style
+  function attachController(target: AnimationTarget): void {
+    controller = createAnimateController(target)
+    controller.setStyle(input.value, { animate: false })
+    controller.setOptions(optionsRef.value)
+  }
+
+  const initialEl = toValue(element)
+  if (initialEl) {
+    attachController(initialEl)
+  }
+
+  // Track element ref changes (ref flipping null → element on mount, etc.).
+  // `flush: 'sync'` so the controller is created and the initial style is
+  // applied to the element in the same tick the template ref is populated,
+  // so callers can observe `el.style` synchronously after mount.
+  watch(
+    () => toValue(element),
+    (el, prevEl) => {
+      if (el === prevEl) return
+      if (controller) {
+        controller.dispose()
+        controller = undefined
+      }
+      if (el) {
+        attachController(el)
+      }
     },
+    { flush: 'sync' },
   )
-  controller.setStyle(input.value)
-  controller.setOptions(optionsRef.value)
 
   function onFinishCurrent(fn: (data: { stopped: boolean }) => void): void {
     // Wait for the next tick to ensure that input changes in the same tick
@@ -89,20 +116,21 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
     //   ...
     // })
     nextTick().then(() => {
-      controller.onFinishCurrent(fn)
+      if (controller) {
+        controller.onFinishCurrent(fn)
+      } else {
+        fn({ stopped: false })
+      }
     })
   }
 
   function onSettleCurrent(fn: (data: { stopped: boolean }) => void): void {
-    // Wait for the next tick to ensure that input changes in the same tick
-    // triggers a new animation that is a case like:
-    //
-    // springStyle.value = { width: '100px' }
-    // onSettleCurrent(() => {
-    //   ...
-    // })
     nextTick().then(() => {
-      controller.onSettleCurrent(fn)
+      if (controller) {
+        controller.onSettleCurrent(fn)
+      } else {
+        fn({ stopped: false })
+      }
     })
   }
 
@@ -124,6 +152,8 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
       () => ({ ...optionsRef.value }),
     ],
     ([disabled, snapshot, options], [prevDisabled, prevSnapshot]) => {
+      if (!controller) return
+
       if (disabled && !prevDisabled) {
         controller.stop({
           keepVelocity: !inferVelocity.value,
@@ -147,8 +177,14 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
     },
   )
 
+  onScopeDispose(() => {
+    if (controller) {
+      controller.dispose()
+      controller = undefined
+    }
+  })
+
   return {
-    style: readonly(style),
     onFinish,
     onSettle,
     onFinishCurrent,

--- a/test/core/animate.test.ts
+++ b/test/core/animate.test.ts
@@ -3,10 +3,10 @@ import { animate } from '../../src/core/animate'
 import { createSpringValue, sv } from '../../src/core/spring-value'
 import type { SpringComputed } from '../../src/core/spring-value'
 
-function spring(value: number): SpringComputed {
-  return createSpringValue(() => value)
-}
-
+// jsdom's CSS.supports doesn't recognize `linear()` or `calc(... exp(...))`,
+// so without this mock animate() falls back to the RAF path, which doesn't
+// touch Element.animate. Force the per-property easing path so assertions on
+// the WAAPI keyframes are exercised.
 vitest.mock('../../src/core/utils', async () => {
   const actual = await vitest.importActual<object>('../../src/core/utils')
   return {
@@ -14,6 +14,14 @@ vitest.mock('../../src/core/utils', async () => {
     isCssLinearTimingFunctionSupported: () => true,
   }
 })
+
+function spring(value: number): SpringComputed {
+  return createSpringValue(() => value)
+}
+
+function el(): HTMLElement {
+  return document.createElement('div')
+}
 
 function raf() {
   return new Promise((resolve) => requestAnimationFrame(resolve))
@@ -25,13 +33,13 @@ function wait(ms: number) {
 
 describe('animate', () => {
   test('ctx.finished and ctx.settled equal to false on start', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }])
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }])
     expect(ctx.finished).toBe(false)
     expect(ctx.settled).toBe(false)
   })
 
   test('ctx.finished = true after duration passed', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 10,
     })
     return new Promise<void>((resolve) => {
@@ -44,7 +52,7 @@ describe('animate', () => {
   })
 
   test('ctx.finished = true after finishingPromise resolved', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 10,
     })
     return new Promise<void>((resolve) => {
@@ -57,7 +65,7 @@ describe('animate', () => {
   })
 
   test('ctx.settled = true after settlingPromise resolved', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 10,
     })
     return new Promise<void>((resolve) => {
@@ -70,7 +78,7 @@ describe('animate', () => {
   })
 
   test('ctx.stop() makes finished and settled be true', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 60000,
     })
     ctx.stop()
@@ -79,7 +87,7 @@ describe('animate', () => {
   })
 
   test('ctx.stop() force resolves finishingPromise', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 60000,
     })
     ctx.stop()
@@ -87,7 +95,7 @@ describe('animate', () => {
   })
 
   test('ctx.stop() force resolves settlingPromise', () => {
-    const ctx = animate(() => {}, [{ scale: 0 }, { scale: 10 }], {
+    const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 60000,
     })
     ctx.stop()
@@ -98,7 +106,7 @@ describe('animate', () => {
     const x = spring(10)
     const y = spring(20)
     const ctx = animate(
-      () => {},
+      el(),
       [
         { x: sv`0`, y: sv`10` },
         { x: sv`${x}`, y: sv`${y}` },
@@ -113,14 +121,14 @@ describe('animate', () => {
 
   test('SpringValue.current() returns a mid-flight value while animating', () => {
     const x = spring(100)
-    animate(() => {}, [{ scale: sv`0` }, { scale: sv`${x}` }])
+    animate(el(), [{ scale: sv`0` }, { scale: sv`${x}` }])
     expect(x.current()).not.toBe(0)
     expect(x.current()).not.toBe(100)
   })
 
   test('SpringValue.current() returns the stopped value when stopped', async () => {
     const x = spring(10)
-    const ctx = animate(() => {}, [{ scale: sv`0` }, { scale: sv`${x}` }], {
+    const ctx = animate(el(), [{ scale: sv`0` }, { scale: sv`${x}` }], {
       duration: 1000,
     })
     await raf()
@@ -134,7 +142,7 @@ describe('animate', () => {
     const x = spring(10)
     const y = spring(20)
     const ctx = animate(
-      () => {},
+      el(),
       [
         { translate: `translate(0px, 10px)` },
         { translate: sv`translate(${x}px, ${y}px)` },
@@ -150,7 +158,7 @@ describe('animate', () => {
 
   test('SpringValue in `from` is attached even when `to` is a literal', () => {
     const x = spring(0)
-    const ctx = animate(() => {}, [{ scale: sv`${x}` }, { scale: '10' }], {
+    const ctx = animate(el(), [{ scale: sv`${x}` }, { scale: '10' }], {
       duration: 10,
     })
     return ctx.settlingPromise.then(() => {
@@ -161,7 +169,7 @@ describe('animate', () => {
   test('SpringValues in both `from` and `to` share the same animation', async () => {
     const a = spring(0)
     const b = spring(10)
-    const ctx = animate(() => {}, [{ scale: sv`${a}` }, { scale: sv`${b}` }], {
+    const ctx = animate(el(), [{ scale: sv`${a}` }, { scale: sv`${b}` }], {
       duration: 1000,
     })
     await raf()
@@ -178,7 +186,7 @@ describe('animate', () => {
   test('velocity set on a `from`-side SpringValue is used as the initial velocity', () => {
     const x = spring(0)
     x.setVelocity(50)
-    animate(() => {}, [{ scale: sv`${x}` }, { scale: '10' }], {
+    animate(el(), [{ scale: sv`${x}` }, { scale: '10' }], {
       duration: 1000,
     })
     expect(x.velocity()).toBeCloseTo(50, 0)
@@ -187,7 +195,7 @@ describe('animate', () => {
   test('velocity set on a `to`-side SpringValue is used as the initial velocity', () => {
     const x = spring(10)
     x.setVelocity(50)
-    animate(() => {}, [{ scale: '0' }, { scale: sv`${x}` }], { duration: 1000 })
+    animate(el(), [{ scale: '0' }, { scale: sv`${x}` }], { duration: 1000 })
     expect(x.velocity()).toBeCloseTo(50, 0)
   })
 
@@ -196,7 +204,7 @@ describe('animate', () => {
     const b = spring(10)
     a.setVelocity(50)
     b.setVelocity(100)
-    animate(() => {}, [{ scale: sv`${a}` }, { scale: sv`${b}` }], {
+    animate(el(), [{ scale: sv`${a}` }, { scale: sv`${b}` }], {
       duration: 1000,
     })
     expect(a.velocity()).toBeCloseTo(50, 0)
@@ -209,7 +217,7 @@ describe('animate', () => {
     x.setVelocity(100)
     y.setVelocity(200)
     const ctx = animate(
-      () => {},
+      el(),
       [
         { x: sv`0`, y: sv`10` },
         { x: sv`${x}`, y: sv`${y}` },
@@ -224,7 +232,7 @@ describe('animate', () => {
 
   test('SpringValue.velocity() is non-zero while animating', () => {
     const x = spring(100)
-    animate(() => {}, [{ scale: sv`0` }, { scale: sv`${x}` }])
+    animate(el(), [{ scale: sv`0` }, { scale: sv`${x}` }])
     expect(x.velocity()).not.toBe(0)
     expect(x.velocity()).not.toBe(100)
   })
@@ -232,7 +240,7 @@ describe('animate', () => {
   test('SpringValue.velocity() is 0 after stopped', async () => {
     const x = spring(10)
     x.setVelocity(100)
-    const ctx = animate(() => {}, [{ scale: sv`0` }, { scale: sv`${x}` }], {
+    const ctx = animate(el(), [{ scale: sv`0` }, { scale: sv`${x}` }], {
       duration: 1000,
     })
     await raf()
@@ -244,7 +252,7 @@ describe('animate', () => {
     const x = spring(10)
     const y = spring(20)
     const ctx = animate(
-      () => {},
+      el(),
       [
         { translate: `translate(0px, 10%)` },
         { translate: sv`translate(${x}px, ${y}%)` },
@@ -258,114 +266,96 @@ describe('animate', () => {
     })
   })
 
-  test('pass compiled style value', async () => {
-    let value: Record<string, string> | undefined
-    const ctx = animate(
-      (v) => {
-        value = v
-      },
+  test('passes resolved keyframes to Element.animate()', () => {
+    const target = el()
+    const calls: {
+      keyframes: Keyframe[]
+      options: KeyframeAnimationOptions
+    }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf, options: opt })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(
+      target,
       [
-        { x: 0, y: `0px` },
-        { x: 10, y: `20px` },
+        { '--x': 0, '--y': `0px` },
+        { '--x': 10, '--y': `20px` },
       ],
-      {
-        duration: 100,
-      },
+      { duration: 100 },
     )
-    expect(value?.x).toBe('0')
-    expect(value?.y).toBe('0px')
-    expect(value?.transition).toBe('none')
-    await raf()
-    await raf()
-    expect(value?.x).toBe('10')
-    expect(value?.y).toBe('20px')
-    expect(value?.transition).not.toBe('none')
-    await ctx.settlingPromise
-    expect(value?.x).toBe('10')
-    expect(value?.y).toBe('20px')
-    expect(value?.transition).toBe('')
+
+    expect(calls.length).toBe(2)
+    expect(calls[0]?.keyframes).toEqual([{ '--x': '0' }, { '--x': '10' }])
+    expect(calls[1]?.keyframes).toEqual([{ '--y': '0px' }, { '--y': '20px' }])
+    expect(calls[0]?.options.fill).toBe('forwards')
+    expect(typeof calls[0]?.options.easing).toBe('string')
   })
 
-  test('pass to style value immediately if the value is not animatable (from is not animatable)', async () => {
-    let value: Record<string, string> | undefined
-    const ctx = animate(
-      (v) => {
-        value = v
-      },
-      [{ width: 'auto' }, { width: '100px' }],
-      {
-        duration: 10,
-      },
-    )
-    expect(value?.width).toBe('100px')
+  test('writes `to` style immediately if the value is not animatable (from is not animatable)', async () => {
+    const target = el()
+    const ctx = animate(target, [{ width: 'auto' }, { width: '100px' }], {
+      duration: 10,
+    })
+    expect(target.style.width).toBe('100px')
     await ctx.settlingPromise
-    expect(value?.width).toBe('100px')
+    expect(target.style.width).toBe('100px')
   })
 
-  test('pass to style value immediately if the value is not animatable (to is not animatable)', async () => {
-    let value: Record<string, string> | undefined
-    const ctx = animate(
-      (v) => {
-        value = v
-      },
-      [{ width: '100px' }, { width: 'auto' }],
-      {
-        duration: 10,
-      },
-    )
-    expect(value?.width).toBe('auto')
+  test('writes `to` style immediately if the value is not animatable (to is not animatable)', async () => {
+    const target = el()
+    const ctx = animate(target, [{ width: '100px' }, { width: 'auto' }], {
+      duration: 10,
+    })
+    expect(target.style.width).toBe('auto')
     await ctx.settlingPromise
-    expect(value?.width).toBe('auto')
+    expect(target.style.width).toBe('auto')
   })
 
-  test('pass real style value after stopped', async () => {
-    let value: Record<string, string> | undefined
+  test('writes the slot value to element.style after settlingPromise', async () => {
+    const target = el()
     const ctx = animate(
-      (v) => {
-        value = v
-      },
-      [{ x: `0px` }, { x: `10px` }],
-      {
-        duration: 10,
-      },
+      target,
+      [
+        { '--x': 0, '--y': `0px` },
+        { '--x': 10, '--y': `20px` },
+      ],
+      { duration: 10 },
     )
+    await ctx.settlingPromise
+    expect(target.style.getPropertyValue('--x')).toBe('10')
+    expect(target.style.getPropertyValue('--y')).toBe('20px')
+  })
+
+  test('writes the mid-flight slot value to element.style after stopped', async () => {
+    const target = el()
+    const ctx = animate(target, [{ '--x': `0px` }, { '--x': `10px` }], {
+      duration: 10,
+    })
     ctx.stop()
     await wait(10)
-    expect(value?.x).not.toBe('0px')
-    expect(value?.x).not.toBe('10px')
+    const x = target.style.getPropertyValue('--x')
+    expect(x).not.toBe('0px')
+    expect(x).not.toBe('10px')
   })
 
-  test('complete `to` style unit from `from` style', async () => {
-    let value: Record<string, string> | undefined
-    const ctx = animate(
-      (v) => {
-        value = v
-      },
-      [{ x: '100%' }, { x: '0' }],
-      {
-        duration: 10,
-      },
-    )
-
-    expect(value?.x).toContain('%')
+  test('completes `to` style unit from `from` style', async () => {
+    const target = el()
+    const ctx = animate(target, [{ '--x': '100%' }, { '--x': '0' }], {
+      duration: 10,
+    })
     await ctx.settlingPromise
-    expect(value?.x).toBe('0%')
+    expect(target.style.getPropertyValue('--x')).toBe('0%')
   })
 
-  test('complete stopped style unit from `from` style', async () => {
-    let value: Record<string, string> | undefined
-    const ctx = animate(
-      (v) => {
-        value = v
-      },
-      [{ x: '100%' }, { x: '0' }],
-      {
-        duration: 10,
-      },
-    )
-
+  test('completes stopped style unit from `from` style', async () => {
+    const target = el()
+    const ctx = animate(target, [{ '--x': '100%' }, { '--x': '0' }], {
+      duration: 10,
+    })
     ctx.stop()
     await ctx.settlingPromise
-    expect(value?.x).toContain('%')
+    expect(target.style.getPropertyValue('--x')).toContain('%')
   })
 })

--- a/test/core/controller.test.ts
+++ b/test/core/controller.test.ts
@@ -1,158 +1,114 @@
-import { describe, expect, test, vi, vitest } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { createAnimateController } from '../../src/core'
-import { t } from '../../src/core/time'
 
-vitest.mock('../../src/core/utils', async () => {
-  const actual = await vitest.importActual<object>('../../src/core/utils')
-  return {
-    ...actual,
-    isCssLinearTimingFunctionSupported: () => true,
-  }
-})
-
-function raf(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+function el(): HTMLElement {
+  return document.createElement('div')
 }
 
 describe('AnimationController', () => {
   test('set initial style', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setStyle({
       width: `100px`,
     })
-    expect(actual?.width).toEqual('100px')
+    expect(target.style.width).toEqual('100px')
   })
 
   test('set style without animation', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setStyle({ width: `100px` })
-    expect(actual).toEqual({ width: '100px', transition: '', [t]: '' })
+    expect(target.style.width).toBe('100px')
     controller.setStyle({ width: `200px` }, { animate: false })
-    expect(actual).toEqual({ width: '200px', transition: '', [t]: '' })
+    expect(target.style.width).toBe('200px')
   })
 
-  test('set style with animation', async () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+  test('set style with animation reaches the to value after settling', async () => {
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: `100px` })
-    expect(actual?.width).toEqual('100px')
+    expect(target.style.width).toEqual('100px')
 
-    controller.setStyle({ width: `200px` })
-    expect(actual?.width).toBe('100px')
-    expect(actual?.transition).toBe('none')
-    await raf()
-    await raf()
-    expect(actual?.width).toBe('200px')
-    expect(actual?.[t]).not.toBe('none')
+    const ctx = controller.setStyle({ width: `200px` })
+    await ctx.settlingPromise
+    expect(target.style.width).toBe('200px')
   })
 
   test('set style without animation if the value is not animatable', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: `auto` })
-    expect(actual?.width).toBe('auto')
+    expect(target.style.width).toBe('auto')
 
     controller.setStyle({ width: `100px` })
-    expect(actual?.width).toBe('100px')
+    expect(target.style.width).toBe('100px')
   })
 
   test('do not trigger animation by setting the same style value', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: `100px` })
-    expect(actual?.width).toBe('100px')
+    expect(target.style.width).toBe('100px')
 
     controller.setStyle({ width: `100px` })
-    expect(actual?.width).toBe('100px')
-    expect(actual?.transition).toBe('')
-    expect(actual?.[t]).toBe('')
+    expect(target.style.width).toBe('100px')
   })
 
   test('trigger animation if any style value is different', async () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: '100px', height: '200px' })
-    expect(actual?.width).toBe('100px')
-    expect(actual?.height).toBe('200px')
+    expect(target.style.width).toBe('100px')
+    expect(target.style.height).toBe('200px')
 
-    controller.setStyle({ width: `100px`, height: `100px` })
-    expect(actual?.width).toBe('100px')
-    expect(actual?.height).toBe('200px')
-    expect(actual?.transition).toBe('none')
-    await raf()
-    await raf()
-    expect(actual?.width).toBe('100px')
-    expect(actual?.height).toBe('100px')
-    expect(actual?.transition).not.toBe('none')
+    const ctx = controller.setStyle({ width: `100px`, height: `100px` })
+    await ctx.settlingPromise
+    expect(target.style.width).toBe('100px')
+    expect(target.style.height).toBe('100px')
   })
 
-  test('complete style unit if the value is 0 without unit', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+  test('complete style unit if the value is 0 without unit', async () => {
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: '100px' })
-    controller.setStyle({ width: '0' })
-    expect(actual?.width).toContain('px')
-
-    return vi.waitFor(() => {
-      expect(actual?.width).toBe('0px')
-    })
+    const ctx = controller.setStyle({ width: '0' })
+    await ctx.settlingPromise
+    expect(target.style.width).toBe('0px')
   })
 
   test('stop animation', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 1000 })
     controller.setStyle({ width: `100px` })
-    expect(actual?.width).toEqual('100px')
+    expect(target.style.width).toEqual('100px')
 
     controller.setStyle({ width: `200px` })
     controller.stop()
-    expect(actual?.width).not.toBe('100px')
-    expect(actual?.width).not.toBe('200px')
-    expect(actual?.transition).toBe('')
-    expect(actual?.[t]).toBe('')
+    expect(target.style.width).not.toBe('100px')
+    expect(target.style.width).not.toBe('200px')
+    expect(target.style.width).toContain('px')
   })
 
   test('complete stopped style unit from the previous style unit', () => {
-    let actual: Record<string, string> | undefined
-    const controller = createAnimateController((style) => {
-      actual = style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 1000 })
     controller.setStyle({ width: '100%' })
     controller.setStyle({ width: '0' })
     controller.stop()
-    expect(actual?.width).toContain('%')
+    expect(target.style.width).toContain('%')
   })
 
   test('register finish listener for the current animation', () => {
-    let style: any
-    const controller = createAnimateController((_style) => {
-      style = _style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -160,17 +116,14 @@ describe('AnimationController', () => {
     return new Promise<void>((resolve) => {
       controller.onFinishCurrent(({ stopped }) => {
         expect(stopped).toBe(false)
-        expect(style.width).not.toBe('100px')
         resolve()
       })
     })
   })
 
   test('register settle listener for the current animation', () => {
-    let style: any
-    const controller = createAnimateController((_style) => {
-      style = _style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -178,17 +131,15 @@ describe('AnimationController', () => {
     return new Promise<void>((resolve) => {
       controller.onSettleCurrent(({ stopped }) => {
         expect(stopped).toBe(false)
-        expect(style.width).toBe('200px')
+        expect(target.style.width).toBe('200px')
         resolve()
       })
     })
   })
 
   test('stopped == true in onFinishCurrent when animation is stopped by stop()', () => {
-    let style: any
-    const controller = createAnimateController((_style) => {
-      style = _style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -196,8 +147,8 @@ describe('AnimationController', () => {
     return new Promise<void>((resolve) => {
       controller.onFinishCurrent(({ stopped }) => {
         expect(stopped).toBe(true)
-        expect(style.width).not.toBe('100px')
-        expect(style.width).not.toBe('200px')
+        expect(target.style.width).not.toBe('100px')
+        expect(target.style.width).not.toBe('200px')
         resolve()
       })
       controller.stop()
@@ -205,7 +156,7 @@ describe('AnimationController', () => {
   })
 
   test('stopped == true in onFinishCurrent when animation is stopped by a new animation', () => {
-    const controller = createAnimateController(() => {})
+    const controller = createAnimateController(el())
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -220,10 +171,8 @@ describe('AnimationController', () => {
   })
 
   test('stopped == true in onSettleCurrent when animation is stopped by stop()', () => {
-    let style: any
-    const controller = createAnimateController((_style) => {
-      style = _style
-    })
+    const target = el()
+    const controller = createAnimateController(target)
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -231,8 +180,8 @@ describe('AnimationController', () => {
     return new Promise<void>((resolve) => {
       controller.onSettleCurrent(({ stopped }) => {
         expect(stopped).toBe(true)
-        expect(style.width).not.toBe('100px')
-        expect(style.width).not.toBe('200px')
+        expect(target.style.width).not.toBe('100px')
+        expect(target.style.width).not.toBe('200px')
         resolve()
       })
       controller.stop()
@@ -240,7 +189,7 @@ describe('AnimationController', () => {
   })
 
   test('stopped == true in onSettleCurrent when animation is stopped by a new animation', () => {
-    const controller = createAnimateController(() => {})
+    const controller = createAnimateController(el())
     controller.setOptions({ duration: 100 })
     controller.setStyle({ width: '100px' }, { animate: false })
     controller.setStyle({ width: '200px' })
@@ -252,5 +201,15 @@ describe('AnimationController', () => {
       })
       controller.setStyle({ width: '300px' })
     })
+  })
+
+  test('dispose stops in-flight animation and clears state', () => {
+    const target = el()
+    const controller = createAnimateController(target)
+    controller.setOptions({ duration: 1000 })
+    controller.setStyle({ width: '100px' })
+    const ctx = controller.setStyle({ width: '200px' })
+    controller.dispose()
+    expect(ctx.settled).toBe(true)
   })
 })

--- a/test/core/controller.test.ts
+++ b/test/core/controller.test.ts
@@ -9,9 +9,10 @@ describe('AnimationController', () => {
   test('set initial style', () => {
     const target = el()
     const controller = createAnimateController(target)
-    controller.setStyle({
+    const ctx = controller.setStyle({
       width: `100px`,
     })
+    expect(ctx.settled).toBe(true)
     expect(target.style.width).toEqual('100px')
   })
 
@@ -20,7 +21,8 @@ describe('AnimationController', () => {
     const controller = createAnimateController(target)
     controller.setStyle({ width: `100px` })
     expect(target.style.width).toBe('100px')
-    controller.setStyle({ width: `200px` }, { animate: false })
+    const ctx = controller.setStyle({ width: `200px` }, { animate: false })
+    expect(ctx.settled).toBe(true)
     expect(target.style.width).toBe('200px')
   })
 
@@ -32,6 +34,7 @@ describe('AnimationController', () => {
     expect(target.style.width).toEqual('100px')
 
     const ctx = controller.setStyle({ width: `200px` })
+    expect(ctx.settled).toBe(false)
     await ctx.settlingPromise
     expect(target.style.width).toBe('200px')
   })
@@ -54,7 +57,8 @@ describe('AnimationController', () => {
     controller.setStyle({ width: `100px` })
     expect(target.style.width).toBe('100px')
 
-    controller.setStyle({ width: `100px` })
+    const ctx = controller.setStyle({ width: `100px` })
+    expect(ctx.settled).toBe(true)
     expect(target.style.width).toBe('100px')
   })
 
@@ -67,6 +71,7 @@ describe('AnimationController', () => {
     expect(target.style.height).toBe('200px')
 
     const ctx = controller.setStyle({ width: `100px`, height: `100px` })
+    expect(ctx.settled).toBe(false)
     await ctx.settlingPromise
     expect(target.style.width).toBe('100px')
     expect(target.style.height).toBe('100px')
@@ -78,6 +83,7 @@ describe('AnimationController', () => {
     controller.setOptions({ duration: 10 })
     controller.setStyle({ width: '100px' })
     const ctx = controller.setStyle({ width: '0' })
+    expect(ctx.settled).toBe(false)
     await ctx.settlingPromise
     expect(target.style.width).toBe('0px')
   })

--- a/test/setup-waapi.ts
+++ b/test/setup-waapi.ts
@@ -1,0 +1,27 @@
+// jsdom does not implement the Web Animations API. We only need
+// `Element.animate` to return an object with a no-op `cancel()` because the
+// library never reads anything else off the returned `Animation`.
+const noop = () => {}
+
+const stubAnimate: Element['animate'] = function () {
+  const animation: Partial<Animation> = {
+    cancel: noop,
+    finish: noop,
+    play: noop,
+    pause: noop,
+    reverse: noop,
+    commitStyles: noop,
+    persist: noop,
+    updatePlaybackRate: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: () => true,
+    finished: Promise.resolve() as unknown as Animation['finished'],
+    ready: Promise.resolve() as unknown as Animation['ready'],
+  }
+  return animation as Animation
+}
+
+if (!Element.prototype.animate) {
+  Element.prototype.animate = stubAnimate
+}

--- a/test/vue/spring-element.test.ts
+++ b/test/vue/spring-element.test.ts
@@ -90,7 +90,10 @@ describe('Spring Element', () => {
       disabled: false,
       inferVelocity: true,
     })
-    expect(mockController.setStyle).toHaveBeenCalledWith({ opacity: 0 })
+    expect(mockController.setStyle).toHaveBeenCalledWith(
+      { opacity: 0 },
+      { animate: true },
+    )
   })
 
   test('disable animation when disabled prop is true', async () => {
@@ -152,7 +155,10 @@ describe('Spring Element', () => {
 
     await nextTick()
 
-    expect(mockController.setStyle).toHaveBeenCalledWith({ height: '100px' })
+    expect(mockController.setStyle).toHaveBeenCalledWith(
+      { height: '100px' },
+      { animate: true },
+    )
     expect(vm.$el.style.height).toBe('100px')
   })
 

--- a/test/vue/use-spring.test.ts
+++ b/test/vue/use-spring.test.ts
@@ -3,23 +3,26 @@ import { useSpring } from '../../src/vue/use-spring'
 import { nextTick, ref } from 'vue'
 
 describe('useSpring', () => {
-  test('return style value', () => {
-    const { style } = useSpring(() => {
+  test('apply initial style on the element synchronously', () => {
+    const el = document.createElement('div')
+    useSpring(el, () => {
       return {
-        width: 10,
+        width: `10px`,
       }
     })
 
-    expect(style.value.width).toBe('10')
+    expect(el.style.width).toBe('10px')
   })
 
   test('update style value immediately when disabled', async () => {
+    const el = document.createElement('div')
     const value = ref(10)
 
-    const { style } = useSpring(
+    useSpring(
+      el,
       () => {
         return {
-          width: value.value,
+          width: `${value.value}px`,
         }
       },
       {
@@ -27,16 +30,18 @@ describe('useSpring', () => {
       },
     )
 
-    expect(style.value.width).toBe('10')
+    expect(el.style.width).toBe('10px')
     value.value = 20
     await nextTick()
-    expect(style.value.width).toBe('20')
+    expect(el.style.width).toBe('20px')
   })
 
   test('register finish listener for the current animation', () => {
+    const el = document.createElement('div')
     const value = ref(10)
 
-    const { style, onFinishCurrent } = useSpring(
+    const { onFinishCurrent } = useSpring(
+      el,
       () => ({
         width: `${value.value}px`,
       }),
@@ -49,16 +54,17 @@ describe('useSpring', () => {
       value.value = 20
       onFinishCurrent(({ stopped }) => {
         expect(stopped).toBe(false)
-        expect(style.value.width).not.toBe('10px')
         resolve()
       })
     })
   })
 
   test('register settle listener for the current animation', () => {
+    const el = document.createElement('div')
     const value = ref(10)
 
-    const { style, onSettleCurrent } = useSpring(
+    const { onSettleCurrent } = useSpring(
+      el,
       () => ({
         width: `${value.value}px`,
       }),
@@ -71,17 +77,19 @@ describe('useSpring', () => {
       value.value = 20
       onSettleCurrent(({ stopped }) => {
         expect(stopped).toBe(false)
-        expect(style.value.width).toBe('20px')
+        expect(el.style.width).toBe('20px')
         resolve()
       })
     })
   })
 
   test('stopped == true in onFinishCurrent when animation is stopped', () => {
+    const el = document.createElement('div')
     const value = ref(10)
     const disabled = ref(false)
 
     const { onFinishCurrent } = useSpring(
+      el,
       () => ({
         width: `${value.value}px`,
       }),
@@ -103,10 +111,12 @@ describe('useSpring', () => {
   })
 
   test('stopped == true in onSettleCurrent when animation is stopped', () => {
+    const el = document.createElement('div')
     const value = ref(10)
     const disabled = ref(false)
 
     const { onSettleCurrent } = useSpring(
+      el,
       () => ({
         width: `${value.value}px`,
       }),

--- a/test/vue/use-spring.test.ts
+++ b/test/vue/use-spring.test.ts
@@ -1,14 +1,28 @@
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { useSpring } from '../../src/vue/use-spring'
-import { nextTick, ref } from 'vue'
+import { EffectScope, effectScope, nextTick, ref } from 'vue'
 
 describe('useSpring', () => {
+  let scope: EffectScope | undefined
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+  })
+
+  function runInScope<T>(fn: () => T): T {
+    scope = effectScope()
+    return scope.run(fn) as T
+  }
+
   test('apply initial style on the element synchronously', () => {
     const el = document.createElement('div')
-    useSpring(el, () => {
-      return {
-        width: `10px`,
-      }
+    runInScope(() => {
+      useSpring(el, () => {
+        return {
+          width: `10px`,
+        }
+      })
     })
 
     expect(el.style.width).toBe('10px')
@@ -18,17 +32,19 @@ describe('useSpring', () => {
     const el = document.createElement('div')
     const value = ref(10)
 
-    useSpring(
-      el,
-      () => {
-        return {
-          width: `${value.value}px`,
-        }
-      },
-      {
-        disabled: true,
-      },
-    )
+    runInScope(() => {
+      useSpring(
+        el,
+        () => {
+          return {
+            width: `${value.value}px`,
+          }
+        },
+        {
+          disabled: true,
+        },
+      )
+    })
 
     expect(el.style.width).toBe('10px')
     value.value = 20
@@ -40,14 +56,16 @@ describe('useSpring', () => {
     const el = document.createElement('div')
     const value = ref(10)
 
-    const { onFinishCurrent } = useSpring(
-      el,
-      () => ({
-        width: `${value.value}px`,
-      }),
-      {
-        duration: 100,
-      },
+    const { onFinishCurrent } = runInScope(() =>
+      useSpring(
+        el,
+        () => ({
+          width: `${value.value}px`,
+        }),
+        {
+          duration: 100,
+        },
+      ),
     )
 
     return new Promise<void>((resolve) => {
@@ -63,14 +81,16 @@ describe('useSpring', () => {
     const el = document.createElement('div')
     const value = ref(10)
 
-    const { onSettleCurrent } = useSpring(
-      el,
-      () => ({
-        width: `${value.value}px`,
-      }),
-      {
-        duration: 100,
-      },
+    const { onSettleCurrent } = runInScope(() =>
+      useSpring(
+        el,
+        () => ({
+          width: `${value.value}px`,
+        }),
+        {
+          duration: 100,
+        },
+      ),
     )
 
     return new Promise<void>((resolve) => {
@@ -88,15 +108,17 @@ describe('useSpring', () => {
     const value = ref(10)
     const disabled = ref(false)
 
-    const { onFinishCurrent } = useSpring(
-      el,
-      () => ({
-        width: `${value.value}px`,
-      }),
-      () => ({
-        duration: 100,
-        disabled: disabled.value,
-      }),
+    const { onFinishCurrent } = runInScope(() =>
+      useSpring(
+        el,
+        () => ({
+          width: `${value.value}px`,
+        }),
+        () => ({
+          duration: 100,
+          disabled: disabled.value,
+        }),
+      ),
     )
 
     value.value = 20
@@ -115,15 +137,17 @@ describe('useSpring', () => {
     const value = ref(10)
     const disabled = ref(false)
 
-    const { onSettleCurrent } = useSpring(
-      el,
-      () => ({
-        width: `${value.value}px`,
-      }),
-      () => ({
-        duration: 100,
-        disabled: disabled.value,
-      }),
+    const { onSettleCurrent } = runInScope(() =>
+      useSpring(
+        el,
+        () => ({
+          width: `${value.value}px`,
+        }),
+        () => ({
+          duration: 100,
+          disabled: disabled.value,
+        }),
+      ),
     )
 
     value.value = 20

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
 
   test: {
     environment: 'jsdom',
+    setupFiles: ['./test/setup-waapi.ts'],
     typecheck: {
       checker: 'vue-tsc',
     },


### PR DESCRIPTION
## Summary

- Major rework of the element animation pipeline (`animate()` / controller / `useSpring`) — see commit `0367aa1` for the bulk of the change
- Inline `springCSSInternal` into `springCSS` (its only caller)
- Strengthen controller tests by asserting `ctx.settled` immediately after `setStyle`, distinguishing real animation contexts from pseudo ones
- Wrap `useSpring` test calls in an `effectScope` so `onScopeDispose` has a scope to attach to and Vue stops warning