### PR TITLE
chore: migrate formatter from prettier to oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "semi": false,
+  "singleQuote": true,
+  "sortPackageJson": true,
+  "sortImports": true,
+  "ignorePatterns": ["pnpm-lock.yaml", "CHANGELOG.md"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-pnpm-lock.yaml
-CHANGELOG.md

--- a/README.ja.md
+++ b/README.ja.md
@@ -86,9 +86,7 @@ const moved = ref(false)
   <!-- ✅ :spring-style のすべての数値が同じ単位、同じ順番で現れている -->
   <spring.div
     :spring-style="{
-      transform: flag
-        ? 'scale(1) translate(100px, 100px)'
-        : 'scale(2) translate(0, 0)',
+      transform: flag ? 'scale(1) translate(100px, 100px)' : 'scale(2) translate(0, 0)',
     }"
   ></spring.div>
 </template>
@@ -116,11 +114,7 @@ function move() {
   <button @click="move">Move</button>
 
   <!-- sv を使って Spring Value を CSS 値に埋め込む -->
-  <spring.div
-    :spring-style="{ translate: sv`${x}px ${y}px` }"
-    :duration="600"
-    :bounce="0.3"
-  />
+  <spring.div :spring-style="{ translate: sv`${x}px ${y}px` }" :duration="600" :bounce="0.3" />
 </template>
 ```
 
@@ -155,11 +149,7 @@ function move() {
 <template>
   <button @click="move">Move</button>
 
-  <spring.div
-    :spring-style="{ translate: sv`${x}px ${y}px` }"
-    :duration="600"
-    :bounce="0.3"
-  />
+  <spring.div :spring-style="{ translate: sv`${x}px ${y}px` }" :duration="600" :bounce="0.3" />
 </template>
 ```
 
@@ -528,11 +518,10 @@ import { animate } from '@ktsn/spring'
 
 const el = document.querySelector('.rectangle') as HTMLElement
 
-const ctx = animate(
-  el,
-  [{ translate: '0px 0px' }, { translate: '300px 300px' }],
-  { duration: 1000, bounce: 0 },
-)
+const ctx = animate(el, [{ translate: '0px 0px' }, { translate: '300px 300px' }], {
+  duration: 1000,
+  bounce: 0,
+})
 
 ctx.settlingPromise.then(() => {
   // スプリングが完全に減衰した

--- a/README.md
+++ b/README.md
@@ -86,9 +86,7 @@ This is because the library parses the numbers in the style value, then calculat
   <!-- ✅ all numbers in the :spring-style have the same unit and are in the same order -->
   <spring.div
     :spring-style="{
-      transform: flag
-        ? 'scale(1) translate(100px, 100px)'
-        : 'scale(2) translate(0, 0)',
+      transform: flag ? 'scale(1) translate(100px, 100px)' : 'scale(2) translate(0, 0)',
     }"
   ></spring.div>
 </template>
@@ -116,11 +114,7 @@ function move() {
   <button @click="move">Move</button>
 
   <!-- Embed spring values into the CSS value via `sv` -->
-  <spring.div
-    :spring-style="{ translate: sv`${x}px ${y}px` }"
-    :duration="600"
-    :bounce="0.3"
-  />
+  <spring.div :spring-style="{ translate: sv`${x}px ${y}px` }" :duration="600" :bounce="0.3" />
 </template>
 ```
 
@@ -155,11 +149,7 @@ function move() {
 <template>
   <button @click="move">Move</button>
 
-  <spring.div
-    :spring-style="{ translate: sv`${x}px ${y}px` }"
-    :duration="600"
-    :bounce="0.3"
-  />
+  <spring.div :spring-style="{ translate: sv`${x}px ${y}px` }" :duration="600" :bounce="0.3" />
 </template>
 ```
 
@@ -536,11 +526,10 @@ import { animate } from '@ktsn/spring'
 
 const el = document.querySelector('.rectangle') as HTMLElement
 
-const ctx = animate(
-  el,
-  [{ translate: '0px 0px' }, { translate: '300px 300px' }],
-  { duration: 1000, bounce: 0 },
-)
+const ctx = animate(el, [{ translate: '0px 0px' }, { translate: '300px 300px' }], {
+  duration: 1000,
+  bounce: 0,
+})
 
 ctx.settlingPromise.then(() => {
   // the spring has fully settled

--- a/demo/picker/App.vue
+++ b/demo/picker/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+
 import { spring, springComputed, sv } from '../../src/vue'
 
 const pickerHeight = 240
@@ -18,20 +19,14 @@ const y = springComputed(() => {
     const realY = y.current()
     const normalizedY = normalizeRealPosition(realY, segmentHeight, centering)
 
-    return loopDirection.value === 'up'
-      ? normalizedY - segmentHeight
-      : normalizedY + segmentHeight
+    return loopDirection.value === 'up' ? normalizedY - segmentHeight : normalizedY + segmentHeight
   }
 
   const itemOffset = itemHeight * (hours.length + selectedIndex.value)
   return centering - itemOffset
 })
 
-function normalizeRealPosition(
-  y: number,
-  segmentHeight: number,
-  centering: number,
-): number {
+function normalizeRealPosition(y: number, segmentHeight: number, centering: number): number {
   if (y <= -segmentHeight * 3 + centering) {
     return normalizeRealPosition(y + segmentHeight, segmentHeight, centering)
   }
@@ -68,13 +63,7 @@ function onWheel(event: WheelEvent): void {
   selectByIndex(nextIndex)
 }
 
-function pickerDeltaByWheel({
-  deltaY,
-  deltaMode,
-}: {
-  deltaY: number
-  deltaMode: number
-}): number {
+function pickerDeltaByWheel({ deltaY, deltaMode }: { deltaY: number; deltaMode: number }): number {
   switch (deltaMode) {
     case WheelEvent.DOM_DELTA_PIXEL: {
       if (deltaY < 0) {
@@ -101,11 +90,7 @@ function onChange(event: Event, index: number): void {
 </script>
 
 <template>
-  <div
-    class="picker"
-    :style="{ height: `${pickerHeight}px` }"
-    @wheel.prevent="onWheel"
-  >
+  <div class="picker" :style="{ height: `${pickerHeight}px` }" @wheel.prevent="onWheel">
     <spring.div
       class="picker-slider"
       :spring-style="{ translate: sv`0px ${y}px` }"

--- a/demo/picker/index.ts
+++ b/demo/picker/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/plain/index.ts
+++ b/demo/plain/index.ts
@@ -5,12 +5,8 @@ let ctx: ReturnType<typeof animate> | undefined
 
 setInterval(() => {
   ctx?.stop()
-  ctx = animate(
-    demo,
-    [{ translate: `0px 0px` }, { translate: `300px 300px` }],
-    {
-      duration: 1000,
-      bounce: 0,
-    },
-  )
+  ctx = animate(demo, [{ translate: `0px 0px` }, { translate: `300px 300px` }], {
+    duration: 1000,
+    bounce: 0,
+  })
 }, 3000)

--- a/demo/swipe/App.vue
+++ b/demo/swipe/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+
 import { spring, springValue, sv } from '../../src/vue'
 
 const dotLeftPosition = {

--- a/demo/swipe/index.ts
+++ b/demo/swipe/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/toggle/App.vue
+++ b/demo/toggle/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+
 import { spring } from '../../src/vue'
 
 const moved = ref(false)

--- a/demo/toggle/index.ts
+++ b/demo/toggle/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/transition-group/App.vue
+++ b/demo/transition-group/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+
 import { SpringTransitionGroup } from '../../src/vue'
 
 const list = ref([1, 2, 3, 4, 5])
@@ -7,11 +8,7 @@ const list = ref([1, 2, 3, 4, 5])
 function onAdd() {
   const max = Math.max(...list.value)
   const index = Math.floor(Math.random() * list.value.length)
-  list.value = [
-    ...list.value.slice(0, index),
-    max + 1,
-    ...list.value.slice(index),
-  ]
+  list.value = [...list.value.slice(0, index), max + 1, ...list.value.slice(index)]
 }
 
 function onRemove() {

--- a/demo/transition-group/index.ts
+++ b/demo/transition-group/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/transition/App.vue
+++ b/demo/transition/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+
 import { SpringTransition } from '../../src/vue'
 
 const isShow = ref(false)

--- a/demo/transition/index.ts
+++ b/demo/transition/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/visualizer/App.vue
+++ b/demo/visualizer/App.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import { ref, shallowRef, watchEffect } from 'vue'
-import {
-  AnimateContext,
-  animate,
-  createSpring,
-  evaluateSpring,
-  sv,
-} from '../../src/core'
+
+import { AnimateContext, animate, createSpring, evaluateSpring, sv } from '../../src/core'
 import { Spring } from '../../src/core/spring'
 import { springValue } from '../../src/vue/spring-value'
 
@@ -224,14 +219,10 @@ watchEffect(() => {
       if (!ball) return
       const fromSv = springValue(from)
       fromSv.setVelocity(velocity)
-      ctx = animate(
-        ball,
-        [{ translate: sv`${fromSv}px` }, { translate: `${to}px` }],
-        {
-          bounce,
-          duration,
-        },
-      )
+      ctx = animate(ball, [{ translate: sv`${fromSv}px` }, { translate: `${to}px` }], {
+        bounce,
+        duration,
+      })
     })
 
     let start: number | undefined
@@ -291,38 +282,14 @@ watchEffect(() => {
 
       <div class="parameter">
         <label>Bounce</label>
-        <input
-          type="range"
-          min="-1"
-          max="1"
-          step="0.01"
-          v-model.number="parameters.bounce"
-        />
-        <input
-          type="number"
-          min="-1"
-          max="1"
-          step="0.1"
-          v-model.number="parameters.bounce"
-        />
+        <input type="range" min="-1" max="1" step="0.01" v-model.number="parameters.bounce" />
+        <input type="number" min="-1" max="1" step="0.1" v-model.number="parameters.bounce" />
       </div>
 
       <div class="parameter">
         <label>Duration</label>
-        <input
-          type="range"
-          min="100"
-          max="5000"
-          step="10"
-          v-model.number="parameters.duration"
-        />
-        <input
-          type="number"
-          min="100"
-          max="5000"
-          step="100"
-          v-model.number="parameters.duration"
-        />
+        <input type="range" min="100" max="5000" step="10" v-model.number="parameters.duration" />
+        <input type="number" min="100" max="5000" step="100" v-model.number="parameters.duration" />
       </div>
     </div>
   </div>

--- a/demo/visualizer/index.ts
+++ b/demo/visualizer/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/demo/vue/App.vue
+++ b/demo/vue/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+
 import { spring } from '../../src/vue'
 
 const to = ref({

--- a/demo/vue/index.ts
+++ b/demo/vue/index.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/package.json
+++ b/package.json
@@ -3,22 +3,22 @@
   "version": "1.0.0-beta.0",
   "description": "Spring animation library for Vue.js",
   "keywords": [
-    "spring",
     "animation",
+    "spring",
     "vue"
   ],
-  "author": "Katashin",
-  "license": "MIT",
   "homepage": "https://github.com/ktsn/spring",
+  "license": "MIT",
+  "author": "Katashin",
   "repository": {
     "type": "git",
     "url": "https://github.com/ktsn/spring.git"
   },
-  "type": "module",
   "files": [
     "dist",
     "types"
   ],
+  "type": "module",
   "main": "./dist/ktsn-spring.umd.cjs",
   "module": "./dist/ktsn-spring.js",
   "types": "./types/vue/index.d.ts",
@@ -35,25 +35,25 @@
     "dts": "vue-tsc",
     "typecheck": "vitest --typecheck",
     "test": "vitest",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
     "demo": "vite build",
     "publish": "./scripts/publish.sh"
-  },
-  "peerDependencies": {
-    "vue": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "25.7.0",
     "@vitejs/plugin-vue": "6.0.6",
     "conventional-changelog-cli": "5.0.0",
     "jsdom": "29.1.1",
-    "prettier": "3.8.3",
+    "oxfmt": "0.50.0",
     "typescript": "6.0.3",
     "vite": "8.0.12",
     "vitest": "4.1.6",
     "vue": "3.5.34",
     "vue-tsc": "3.2.8"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
   },
   "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
-      prettier:
-        specifier: 3.8.3
-        version: 3.8.3
+      oxfmt:
+        specifier: 0.50.0
+        version: 0.50.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -166,6 +166,128 @@ packages:
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@oxfmt/binding-android-arm-eabi@0.50.0':
+    resolution: {integrity: sha512-ICXQVKrDvsWUtfx6EiVJxfWrajKTwTfRV8vz2XiMkxZeuCKJLgD4YAj6dE3BWvpqDlkVkie4VSTAtMUWO9LDXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.50.0':
+    resolution: {integrity: sha512-quwjLQFkuW6OwLHeDeIXsTzOmipQFQbqsYN9HLk2B5I01IlAQZHP1UiLIg0O7pP+dUgPD2AD7SCYA3gs6NH5/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.50.0':
+    resolution: {integrity: sha512-ikU5umElcMi78/TNI334wtjr5WZ5F4nWa1aIDseAKKGL0W3ygxeYKkrIJ0fggWa8MOon66BmG3xCqmX1m9YAOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.50.0':
+    resolution: {integrity: sha512-WT4MOYG4mv9IXrH0m60vHsJh+rRMPSOKTQmwDpwmgQ+DuW/i5dU4pqc0HDO5uclO5vjz5IFX5z/taW86LSVe/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.50.0':
+    resolution: {integrity: sha512-gH0rycVXqV4juWkvLs2uPMtTyppDc7qEUVzXAxnQ7FpcSZNXqKowUgtjH8q67ngj416r8+4NnAlyR/D35zwwhQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.50.0':
+    resolution: {integrity: sha512-wL/k+o0hiTeRvi/gPzeC1L/yTHTXIeHDKWU09s2zTBmv7ma59wTm+fADNSGYxhJQDxyavQbwTf1QpW3Zj924tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.50.0':
+    resolution: {integrity: sha512-Y59FKqoUM3Gf00E395b4ixfWyJGwO2GzaZawF5MZoVWcb3f6CkWUXyao0jyOvoIxDMzMybcVRuXyG7ih/Nxweg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.50.0':
+    resolution: {integrity: sha512-OvXbfTjMignXWyJXg/NOFsiy996vFe8wb9tkxJaUq8ylq0XrzJg3ttavC5Tcmm6F8/GUs2r3XFJWWu9q/27uYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.50.0':
+    resolution: {integrity: sha512-rqmvHZm7vMa3NLYa0khwkhReCmp9tqKnF23TFZ7S5cYJLvIE4b0k8famWE7kO897/DXznJe675n5SohFBggbxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.50.0':
+    resolution: {integrity: sha512-49bAdYbMSde42tzPDtuHnBWzOgmoS0PT9THCjvMnDVYMQYiHzPc2Mv5rkpBHVQOXM+PHfafJlxgK0anXSWBVvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.50.0':
+    resolution: {integrity: sha512-VFT25/6kckkIM62KeWB2bi+xCEmC/zC+DcMaIpEfaio8ulkGDLSiTz11TyK0eqgTl3x5OklYEGDWohvAgOr8Bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.50.0':
+    resolution: {integrity: sha512-BBJMuNy6jjkXjUUINF5UTQqb/nvjmtJad43Gp7bab0AAURAdthhJvduR7rHpWInpWYiaMzYsdrmURNcrmpxdZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.50.0':
+    resolution: {integrity: sha512-Xd4y+yjAYHKmryXhyUUwbyRD01iKfcvI74iE01L6p4F8SwjhZQXDshK+T8PcrPZLiFqH263P5xqJk94amjkjzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.50.0':
+    resolution: {integrity: sha512-Qp96rYJru7l++7mk4R+eh8qq9GFfFAMdmoN6VGoRHI8AA1XMnUIzH4u+zOcKZZwY+irHdsaBldDearwB4nOH7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.50.0':
+    resolution: {integrity: sha512-5XLGp+yd5w2Key5LMqJO+X3XVsJKgeeUKljy32+MBF/J/JZ5m8WHl6dI5eOQOr3ixopxPiXIyDAxn3slI3UXiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.50.0':
+    resolution: {integrity: sha512-QAxwzh7+GHugCD7WuERolVs8TKQwXNIAZXAHHTecbKVc9oWBkWzOiLauQuezXS57tVcof5zhi1IjZ8tOV0htTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.50.0':
+    resolution: {integrity: sha512-3nKN/kqClm9iCFWTwtJ9UpR5SGyExp5l3nw6uIiBt+3XitQtszin+vjHrL7JHfDksZ7Svigdaow2zqz/IKCfqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.50.0':
+    resolution: {integrity: sha512-3r6XZ8+X6qlLbXaPW2NygfiAWSpKbkE36pAVzS83mY+cYY+pSMalJ+qnCgkr92tr+Iqv988XKQ1CpARTg9ITbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.50.0':
+    resolution: {integrity: sha512-BSE8D8KsvquMG9vU+Qt4qGuoOcZ36rxU5S6ZkHNguj+MlWkXWCBETnno3yJ9CfWvfCrbmieaN9LK6hdcdHNZ/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -687,6 +809,16 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oxfmt@0.50.0:
+    resolution: {integrity: sha512-owwjTnhfM5aCOJhYeqDvk7iM504OeYFZpdRU7cxx7xtZMo4uVpjlryTUon+Cf76CugsvnqA32e6rC73pr1hXaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -710,11 +842,6 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -796,6 +923,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -1087,6 +1218,63 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.129.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.50.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.50.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
@@ -1585,6 +1773,30 @@ snapshots:
 
   obug@2.1.1: {}
 
+  oxfmt@0.50.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.50.0
+      '@oxfmt/binding-android-arm64': 0.50.0
+      '@oxfmt/binding-darwin-arm64': 0.50.0
+      '@oxfmt/binding-darwin-x64': 0.50.0
+      '@oxfmt/binding-freebsd-x64': 0.50.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.50.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.50.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.50.0
+      '@oxfmt/binding-linux-arm64-musl': 0.50.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.50.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.50.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.50.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.50.0
+      '@oxfmt/binding-linux-x64-gnu': 0.50.0
+      '@oxfmt/binding-linux-x64-musl': 0.50.0
+      '@oxfmt/binding-openharmony-arm64': 0.50.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.50.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.50.0
+      '@oxfmt/binding-win32-x64-msvc': 0.50.0
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -1608,8 +1820,6 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prettier@3.8.3: {}
 
   punycode@2.3.1: {}
 
@@ -1696,6 +1906,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,0 @@
-export default {
-  semi: false,
-  singleQuote: true,
-}

--- a/scripts/bundle-size-report.ts
+++ b/scripts/bundle-size-report.ts
@@ -49,9 +49,7 @@ const baseSha = process.env.BASE_SHA
 const headSha = process.env.HEAD_SHA
 if (baseSha || headSha) {
   lines.push('')
-  lines.push(
-    `Base: \`${(baseSha ?? '').slice(0, 7)}\` · Head: \`${(headSha ?? '').slice(0, 7)}\``,
-  )
+  lines.push(`Base: \`${(baseSha ?? '').slice(0, 7)}\` · Head: \`${(headSha ?? '').slice(0, 7)}\``)
 }
 
 process.stdout.write(lines.join('\n') + '\n')

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -1,8 +1,9 @@
-import { build } from 'vite'
 import { readFileSync, statSync } from 'node:fs'
-import { gzipSync } from 'node:zlib'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+
+import { build } from 'vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageRoot = path.resolve(__dirname, '..')

--- a/src/core/animate.ts
+++ b/src/core/animate.ts
@@ -1,4 +1,3 @@
-import { registerPropertyIfNeeded, t, wait } from './time'
 import {
   generateSpringExpressionStyle,
   createSpring,
@@ -6,6 +5,20 @@ import {
   springEasingFn,
   Spring,
 } from './spring'
+import {
+  SpringComputed,
+  SpringStyleValue,
+  attachSpringValue,
+  liftToSpringStyle,
+  snapshotSpringStyle,
+} from './spring-value'
+import {
+  ParsedStyleValue,
+  completeParsedStyleUnit,
+  interpolateParsedStyle,
+  parseStyleValue,
+} from './style'
+import { registerPropertyIfNeeded, t, wait } from './time'
 import {
   clearStyle,
   isCssLinearTimingFunctionSupported,
@@ -16,19 +29,6 @@ import {
   writeStyle,
   zip,
 } from './utils'
-import {
-  ParsedStyleValue,
-  completeParsedStyleUnit,
-  interpolateParsedStyle,
-  parseStyleValue,
-} from './style'
-import {
-  SpringComputed,
-  SpringStyleValue,
-  attachSpringValue,
-  liftToSpringStyle,
-  snapshotSpringStyle,
-} from './spring-value'
 
 export type AnimationTarget = HTMLElement | SVGElement
 
@@ -53,13 +53,8 @@ export interface AnimateContext {
 export function animate<
   From extends Record<string, AnimateValue | null | undefined>,
   To extends Record<string, AnimateValue | null | undefined>,
->(
-  target: AnimationTarget,
-  fromTo: [To] | [From, To],
-  options: SpringOptions = {},
-): AnimateContext {
-  const [rawFrom, rawTo] =
-    fromTo.length === 1 ? [{} as From, fromTo[0]] : fromTo
+>(target: AnimationTarget, fromTo: [To] | [From, To], options: SpringOptions = {}): AnimateContext {
+  const [rawFrom, rawTo] = fromTo.length === 1 ? [{} as From, fromTo[0]] : fromTo
   const { fromInput, toInput } = resolveMissingEntries(target, rawFrom, rawTo)
 
   // Each slot — whether the user passed a SpringValue or a plain number —
@@ -209,9 +204,7 @@ interface InputValueGroup {
   velocity: number
 }
 
-function groupInputValues<
-  FromTo extends Record<string, [ParsedStyleValue, ParsedStyleValue]>,
->(
+function groupInputValues<FromTo extends Record<string, [ParsedStyleValue, ParsedStyleValue]>>(
   fromTo: FromTo,
   velocity: Record<keyof FromTo, number[]>,
 ): Record<keyof FromTo, InputValueGroup[]> {
@@ -284,20 +277,17 @@ function animateWithPerPropertyEasing({
     const toStr = interpolateParsedStyle(completedTo, completedTo.values)
 
     const values = inputValues[key]!
-    const normalizedVelocity = values.reduce<number | undefined>(
-      (acc, { from, to, velocity }) => {
-        if (acc !== undefined) {
-          return acc
-        }
+    const normalizedVelocity = values.reduce<number | undefined>((acc, { from, to, velocity }) => {
+      if (acc !== undefined) {
+        return acc
+      }
 
-        if (from === to) {
-          return undefined
-        }
+      if (from === to) {
+        return undefined
+      }
 
-        return velocity / (to - from)
-      },
-      undefined,
-    )
+      return velocity / (to - from)
+    }, undefined)
 
     const easing = springEasingFn({
       spring,
@@ -305,10 +295,11 @@ function animateWithPerPropertyEasing({
       normalizedVelocity: normalizedVelocity ?? 0,
     })
 
-    const a = target.animate(
-      [keyframeFor(key, fromStr), keyframeFor(key, toStr)],
-      { duration: settlingDuration, easing, fill: 'forwards' },
-    )
+    const a = target.animate([keyframeFor(key, fromStr), keyframeFor(key, toStr)], {
+      duration: settlingDuration,
+      easing,
+      fill: 'forwards',
+    })
     animations.push(a)
   }
 
@@ -354,10 +345,11 @@ function animateWithProxyTimeVariable({
 
   target.style.setProperty(t, '0')
 
-  const a = target.animate(
-    [{ [t]: '0' }, { [t]: String(settlingDuration / duration) }],
-    { duration: settlingDuration, easing: 'linear', fill: 'forwards' },
-  )
+  const a = target.animate([{ [t]: '0' }, { [t]: String(settlingDuration / duration) }], {
+    duration: settlingDuration,
+    easing: 'linear',
+    fill: 'forwards',
+  })
   return [a]
 }
 
@@ -398,9 +390,7 @@ function animateWithRaf({
   render()
 }
 
-function createContext<
-  FromTo extends Record<string, [ParsedStyleValue, ParsedStyleValue]>,
->({
+function createContext<FromTo extends Record<string, [ParsedStyleValue, ParsedStyleValue]>>({
   target,
   slots,
   fromTo,

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -1,24 +1,13 @@
-import {
-  AnimateContext,
-  AnimateValue,
-  AnimationTarget,
-  SpringOptions,
-  animate,
-} from './animate'
-import { writeStyle } from './utils'
-import {
-  ParsedStyleValue,
-  StyleValue,
-  interpolateParsedStyle,
-  parseStyleValue,
-} from './style'
+import { AnimateContext, AnimateValue, AnimationTarget, SpringOptions, animate } from './animate'
 import {
   SpringComputed,
   SpringStyleValue,
   liftToSpringStyle,
   snapshotSpringStyle,
 } from './spring-value'
+import { ParsedStyleValue, StyleValue, interpolateParsedStyle, parseStyleValue } from './style'
 import { t } from './time'
+import { writeStyle } from './utils'
 import { mapValues } from './utils'
 
 export interface SetStyleOptions<StyleKey extends keyof any> {
@@ -30,13 +19,8 @@ export interface StopOptions {
   keepVelocity?: boolean
 }
 
-export interface AnimationController<
-  Style extends Record<string, AnimateValue>,
-> {
-  setStyle: (
-    style: Style,
-    options?: SetStyleOptions<keyof Style>,
-  ) => AnimateContext
+export interface AnimationController<Style extends Record<string, AnimateValue>> {
+  setStyle: (style: Style, options?: SetStyleOptions<keyof Style>) => AnimateContext
 
   setOptions: (options: SpringOptions) => void
 
@@ -53,9 +37,9 @@ interface ValueHistoryItem<Key extends PropertyKey> {
   timestamp: number
 }
 
-export function createAnimateController<
-  Style extends Record<string, AnimateValue>,
->(target: AnimationTarget): AnimationController<Style> {
+export function createAnimateController<Style extends Record<string, AnimateValue>>(
+  target: AnimationTarget,
+): AnimationController<Style> {
   /** Holding the snapshotted form of the most recently committed style */
   let style: Record<keyof Style, ParsedStyleValue> | undefined
 
@@ -105,22 +89,15 @@ export function createAnimateController<
     return mapValues(next, (value) => new Array(value.values.length).fill(0))
   }
 
-  function commitStaticStyle(
-    parsed: Record<keyof Style, ParsedStyleValue>,
-  ): void {
+  function commitStaticStyle(parsed: Record<keyof Style, ParsedStyleValue>): void {
     for (const key in parsed) {
-      writeStyle(
-        target,
-        key,
-        interpolateParsedStyle(parsed[key], parsed[key].values),
-      )
+      writeStyle(target, key, interpolateParsedStyle(parsed[key], parsed[key].values))
     }
     target.style.removeProperty(t)
   }
 
   function stop({ keepVelocity }: StopOptions = {}): void {
-    keptVelocity =
-      keepVelocity && liveSlots ? liveRealVelocity(liveSlots) : undefined
+    keptVelocity = keepVelocity && liveSlots ? liveRealVelocity(liveSlots) : undefined
 
     if (ctx && !ctx.settled) {
       ctx.stop()
@@ -134,18 +111,13 @@ export function createAnimateController<
     valueHistory = []
   }
 
-  function setStyle(
-    nextStyle: Style,
-    params: SetStyleOptions<keyof Style> = {},
-  ): AnimateContext {
+  function setStyle(nextStyle: Style, params: SetStyleOptions<keyof Style> = {}): AnimateContext {
     const isAnimate = params.animate ?? true
 
     const wrappedParsedStyle: Record<keyof Style, SpringStyleValue> = mapValues(
       nextStyle,
       (value): SpringStyleValue =>
-        typeof value === 'object'
-          ? value
-          : liftToSpringStyle(parseStyleValue(String(value))),
+        typeof value === 'object' ? value : liftToSpringStyle(parseStyleValue(String(value))),
     )
 
     const parsedStyleSnap = mapValues(wrappedParsedStyle, snapshotSpringStyle)
@@ -156,8 +128,7 @@ export function createAnimateController<
 
     const newSlots = mapValues(wrappedParsedStyle, (p) => p.values)
 
-    const inferredVelocity =
-      params.velocity ?? getRealVelocity(wrappedParsedStyle)
+    const inferredVelocity = params.velocity ?? getRealVelocity(wrappedParsedStyle)
 
     // Write inferred velocity onto every new slot
     for (const key in wrappedParsedStyle) {
@@ -323,9 +294,10 @@ function createPseudoContext(): AnimateContext {
   }
 }
 
-export function isSameStyle<
-  Style extends Record<string, number | string | StyleValue<unknown>>,
->(a: Style, b: Style): boolean {
+export function isSameStyle<Style extends Record<string, number | string | StyleValue<unknown>>>(
+  a: Style,
+  b: Style,
+): boolean {
   const keys = new Set([...Object.keys(a), ...Object.keys(b)])
 
   return Array.from(keys).every((key) => {
@@ -338,9 +310,6 @@ export function isSameStyle<
 
     const aValues = aValue.values
     const bValues = bValue.values
-    return (
-      aValues.length === bValues.length &&
-      aValues.every((value, i) => value === bValues[i])
-    )
+    return aValues.length === bValues.length && aValues.every((value, i) => value === bValues[i])
   })
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,10 +1,5 @@
 export { animate } from './animate'
-export type {
-  AnimateContext,
-  AnimateValue,
-  AnimationTarget,
-  SpringOptions,
-} from './animate'
+export type { AnimateContext, AnimateValue, AnimationTarget, SpringOptions } from './animate'
 
 export { createAnimateController } from './controller'
 export type { AnimationController } from './controller'
@@ -23,11 +18,6 @@ export { interpolateParsedStyle } from './style'
 export type { ParsedStyleValue } from './style'
 
 export { sv } from './spring-value'
-export type {
-  SpringComputed,
-  SpringStyleValue,
-  SpringValue,
-  SvInterpolation,
-} from './spring-value'
+export type { SpringComputed, SpringStyleValue, SpringValue, SvInterpolation } from './spring-value'
 
 export * from './utils'

--- a/src/core/spring-value.ts
+++ b/src/core/spring-value.ts
@@ -1,3 +1,4 @@
+import { Spring, evaluateSpring } from './spring'
 import {
   ParsedStyleValue,
   StyleValue,
@@ -5,7 +6,6 @@ import {
   parseLeadingUnit,
   parseStyleValue,
 } from './style'
-import { Spring, evaluateSpring } from './spring'
 
 const SPRING_VALUE_BRAND: unique symbol = Symbol('springValue')
 
@@ -114,9 +114,7 @@ export function createSpringValue(
     },
 
     velocity(): number {
-      return obj._attachment
-        ? evaluateAttachmentVelocity(obj._attachment)
-        : velocity
+      return obj._attachment ? evaluateAttachmentVelocity(obj._attachment) : velocity
     },
 
     setVelocity(v: number): void {
@@ -154,10 +152,7 @@ export function createSpringValue(
   return obj as InternalSpring
 }
 
-export function attachSpringValue(
-  value: SpringComputed,
-  attachment: Attachment,
-): void {
+export function attachSpringValue(value: SpringComputed, attachment: Attachment): void {
   ;(value as InternalSpring)._attachment = attachment
 }
 
@@ -181,10 +176,7 @@ export type SvInterpolation = number | string | SpringComputed
  * </template>
  * ```
  */
-export function sv(
-  strings: TemplateStringsArray,
-  ...values: SvInterpolation[]
-): SpringStyleValue {
+export function sv(strings: TemplateStringsArray, ...values: SvInterpolation[]): SpringStyleValue {
   const parts: SpringStyleValue[] = []
 
   // Parse the leading static string

--- a/src/core/spring.ts
+++ b/src/core/spring.ts
@@ -25,10 +25,7 @@ interface SpringDataAtTime extends SpringData {
   time: number
 }
 
-export function generateSpringExpressionStyle(
-  spring: Spring,
-  data: SpringData,
-): string {
+export function generateSpringExpressionStyle(spring: Spring, data: SpringData): string {
   if (isNotAnimating(data)) {
     return `calc(${data.to})`
   }
@@ -39,12 +36,7 @@ export function evaluateSpring(spring: Spring, data: SpringDataAtTime): number {
   if (isNotAnimating(data)) {
     return data.to
   }
-  return (
-    volume(data.from, data.to) *
-      spring.bounceValue(data) *
-      spring.decayValue(data) +
-    data.to
-  )
+  return volume(data.from, data.to) * spring.bounceValue(data) * spring.decayValue(data) + data.to
 }
 
 export interface SpringGeneratorResult {
@@ -62,10 +54,7 @@ export interface SpringGenerator {
  *
  * We check both the distance to 'to' value, and the velocity to calculate it.
  */
-export function springSettlingDuration(
-  spring: Spring,
-  data: SpringData,
-): number {
+export function springSettlingDuration(spring: Spring, data: SpringData): number {
   const volume = Math.abs(data.from - data.to)
 
   // Set max duration to make sure the animation eventually ends.
@@ -230,10 +219,7 @@ export function springEasingFn(params: {
 /**
  * https://developer.apple.com/videos/play/wwdc2023/10158/
  */
-export function createSpring(data: {
-  bounce: number
-  duration: number
-}): Spring {
+export function createSpring(data: { bounce: number; duration: number }): Spring {
   if (data.bounce > 0) {
     return bouncySpring(data)
   } else if (data.bounce < 0) {
@@ -381,10 +367,7 @@ function bouncySpring({ bounce, duration }: SpringTypeData): Spring {
       const time = data.time
 
       // Derivative of bouncy spring expression
-      const v =
-        -A *
-        Math.exp(-c * time) *
-        (c * Math.cos(a * time + b) + a * Math.sin(a * time + b))
+      const v = -A * Math.exp(-c * time) * (c * Math.cos(a * time + b) + a * Math.sin(a * time + b))
 
       return denormalizeVelocity(v, {
         ...data,
@@ -499,11 +482,8 @@ function flattenedSpring({ bounce, duration }: SpringTypeData): Spring {
 
       // Derivative of flattened spring expression
       const v =
-        Math.exp(-c * time) *
-          (a * A * Math.exp(a * time) - a * B * Math.exp(-a * time)) -
-        c *
-          Math.exp(-c * time) *
-          (A * Math.exp(a * time) + B * Math.exp(-a * time))
+        Math.exp(-c * time) * (a * A * Math.exp(a * time) - a * B * Math.exp(-a * time)) -
+        c * Math.exp(-c * time) * (A * Math.exp(a * time) + B * Math.exp(-a * time))
 
       return denormalizeVelocity(v, {
         ...data,

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -3,11 +3,7 @@ export const t = '--ktsn-spring-time'
 let registered = false
 
 export function registerPropertyIfNeeded() {
-  if (
-    typeof CSS === 'undefined' ||
-    typeof CSS.registerProperty !== 'function' ||
-    registered
-  ) {
+  if (typeof CSS === 'undefined' || typeof CSS.registerProperty !== 'function' || registered) {
     return
   }
 
@@ -20,10 +16,7 @@ export function registerPropertyIfNeeded() {
   registered = true
 }
 
-export function wait(
-  duration: number,
-  forceResolve?: { fn: (() => void)[] },
-): Promise<void> {
+export function wait(duration: number, forceResolve?: { fn: (() => void)[] }): Promise<void> {
   let resolved = false
   let timer: ReturnType<typeof setTimeout>
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,10 +1,6 @@
 import type { AnimationTarget } from './animate'
 
-export function writeStyle(
-  target: AnimationTarget,
-  key: string,
-  value: string,
-): void {
+export function writeStyle(target: AnimationTarget, key: string, value: string): void {
   if (key.startsWith('--')) {
     target.style.setProperty(key, value)
   } else {
@@ -56,17 +52,11 @@ export function range(start: number, end: number): number[] {
 }
 
 export function isWebAnimationsApiSupported(): boolean {
-  return (
-    typeof Element !== 'undefined' &&
-    typeof Element.prototype.animate === 'function'
-  )
+  return typeof Element !== 'undefined' && typeof Element.prototype.animate === 'function'
 }
 
 export function isCssLinearTimingFunctionSupported(): boolean {
-  return (
-    typeof CSS !== 'undefined' &&
-    CSS.supports('transition-timing-function', 'linear(0, 1)')
-  )
+  return typeof CSS !== 'undefined' && CSS.supports('transition-timing-function', 'linear(0, 1)')
 }
 
 export function isCssMathAnimationSupported(): boolean {

--- a/src/vue/SpringTransition.ts
+++ b/src/vue/SpringTransition.ts
@@ -1,10 +1,6 @@
 import { PropType, Transition, computed, defineComponent, h } from 'vue'
-import {
-  AnimateValue,
-  AnimationController,
-  createAnimateController,
-  forceReflow,
-} from '../core'
+
+import { AnimateValue, AnimationController, createAnimateController, forceReflow } from '../core'
 
 // sc = Spring Controller
 export const scKey = Symbol('SpringController')
@@ -174,13 +170,9 @@ export const springTransitionProps = {
 
   leaveTo: Object as PropType<Record<string, AnimateValue>>,
 
-  bounce: [Number, Object] as PropType<
-    number | { enter: number; leave: number }
-  >,
+  bounce: [Number, Object] as PropType<number | { enter: number; leave: number }>,
 
-  duration: [Number, Object] as PropType<
-    number | { enter: number; leave: number }
-  >,
+  duration: [Number, Object] as PropType<number | { enter: number; leave: number }>,
 } as const
 
 const SpringTransition = defineComponent({

--- a/src/vue/SpringTransitionGroup.ts
+++ b/src/vue/SpringTransitionGroup.ts
@@ -9,6 +9,8 @@ import {
   onUpdated,
   vShow,
 } from 'vue'
+
+import { createAnimateController, forceReflow } from './index.ts'
 import {
   HTMLElementWithController,
   SpringTransitionProps,
@@ -16,12 +18,8 @@ import {
   springTransitionProps,
   useTransitionHooks,
 } from './SpringTransition.ts'
-import { createAnimateController, forceReflow } from './index.ts'
 
-interface SpringTransitionGroupProps extends Omit<
-  SpringTransitionProps,
-  'mode'
-> {
+interface SpringTransitionGroupProps extends Omit<SpringTransitionProps, 'mode'> {
   tag?: string
   bounce?: number | { move?: number; enter?: number; leave?: number }
   duration?: number | { move?: number; enter?: number; leave?: number }
@@ -40,9 +38,7 @@ const springTransitionGroupProps = {
 
   tag: String,
 
-  bounce: [Number, Object] as PropType<
-    number | { move?: number; enter?: number; leave?: number }
-  >,
+  bounce: [Number, Object] as PropType<number | { move?: number; enter?: number; leave?: number }>,
 
   duration: [Number, Object] as PropType<
     number | { move?: number; enter?: number; leave?: number }
@@ -97,15 +93,11 @@ const SpringTransitionGroup = defineComponent({
     )
 
     const moveBounce = computed(() => {
-      return typeof props.bounce === 'number'
-        ? props.bounce
-        : props.bounce?.move
+      return typeof props.bounce === 'number' ? props.bounce : props.bounce?.move
     })
 
     const movedDuration = computed(() => {
-      return typeof props.duration === 'number'
-        ? props.duration
-        : props.duration?.move
+      return typeof props.duration === 'number' ? props.duration : props.duration?.move
     })
 
     onUpdated(() => {

--- a/src/vue/directives.ts
+++ b/src/vue/directives.ts
@@ -1,10 +1,6 @@
 import { App, Directive } from 'vue'
-import {
-  AnimateValue,
-  AnimationController,
-  SpringOptions,
-  createAnimateController,
-} from '../core'
+
+import { AnimateValue, AnimationController, SpringOptions, createAnimateController } from '../core'
 
 interface HTMLElementWithController extends HTMLElement {
   __springController?: AnimationController<Record<string, AnimateValue>>
@@ -19,10 +15,11 @@ export const springDirectives = {
   install,
 }
 
-const springStyle: Directive<
-  HTMLElementWithController,
-  Record<string, AnimateValue>
-> = (el, { value }, vnode) => {
+const springStyle: Directive<HTMLElementWithController, Record<string, AnimateValue>> = (
+  el,
+  { value },
+  vnode,
+) => {
   const controller = ensureController(el)
 
   vnode.dirs?.forEach((dir) => {

--- a/src/vue/spring-element.ts
+++ b/src/vue/spring-element.ts
@@ -1,15 +1,14 @@
 import { PropType, defineComponent, h, ref } from 'vue'
+
 import { AnimateValue } from '../core'
-import { useSpring } from './use-spring'
 import { SpringStyleValue } from '../core/spring-value'
+import { useSpring } from './use-spring'
 
 const createSpringElement = (tagName: string) => {
   return defineComponent({
     props: {
       springStyle: {
-        type: Object as PropType<
-          Record<string, AnimateValue | SpringStyleValue>
-        >,
+        type: Object as PropType<Record<string, AnimateValue | SpringStyleValue>>,
         required: true,
       },
       bounce: Number,
@@ -58,10 +57,7 @@ const createSpringElement = (tagName: string) => {
   })
 }
 
-const springElementRecord: Record<
-  string,
-  ReturnType<typeof createSpringElement>
-> = {}
+const springElementRecord: Record<string, ReturnType<typeof createSpringElement>> = {}
 
 export const spring = new Proxy(springElementRecord, {
   get: (record, tagName) => {

--- a/src/vue/spring-value.ts
+++ b/src/vue/spring-value.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+
 import { createSpringValue } from '../core/spring-value'
 import type { SpringComputed, SpringValue } from '../core/spring-value'
 

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -1,12 +1,5 @@
-import {
-  MaybeRefOrGetter,
-  Ref,
-  computed,
-  nextTick,
-  onScopeDispose,
-  toValue,
-  watch,
-} from 'vue'
+import { MaybeRefOrGetter, Ref, computed, nextTick, onScopeDispose, toValue, watch } from 'vue'
+
 import {
   AnimateValue,
   AnimationController,
@@ -61,10 +54,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
       }
     }
 
-    return (hasSpringValue ? resolved : raw) as Record<
-      keyof Style,
-      string | number
-    >
+    return (hasSpringValue ? resolved : raw) as Record<keyof Style, string | number>
   })
 
   const optionsRef = computed(() => toValue(options) ?? {})
@@ -73,9 +63,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
 
   const inferVelocity = computed(() => optionsRef.value.inferVelocity ?? true)
 
-  let controller:
-    | AnimationController<Record<keyof Style, AnimateValue>>
-    | undefined
+  let controller: AnimationController<Record<keyof Style, AnimateValue>> | undefined
 
   function attachController(target: AnimationTarget): void {
     controller = createAnimateController(target)
@@ -146,11 +134,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
   }
 
   watch(
-    [
-      disabled,
-      () => ({ ...inputSnapshot.value }),
-      () => ({ ...optionsRef.value }),
-    ],
+    [disabled, () => ({ ...inputSnapshot.value }), () => ({ ...optionsRef.value })],
     ([disabled, snapshot, options], [prevDisabled, prevSnapshot]) => {
       if (!controller) return
 

--- a/test/core/animate.test.ts
+++ b/test/core/animate.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vitest } from 'vitest'
 import type { MockInstance } from 'vitest'
+
 import { animate } from '../../src/core/animate'
 import { createSpringValue, sv } from '../../src/core/spring-value'
 import type { SpringComputed } from '../../src/core/spring-value'
@@ -62,10 +63,7 @@ function mockComputedWhenInlineCleared(
         get(t, prop, receiver) {
           if (prop === 'getPropertyValue') {
             return (name: string) => {
-              if (
-                name in overrides &&
-                target.style.getPropertyValue(name) === ''
-              ) {
+              if (name in overrides && target.style.getPropertyValue(name) === '') {
                 return overrides[name]
               }
               return t.getPropertyValue(name)
@@ -191,10 +189,7 @@ describe('animate', () => {
     const y = spring(20)
     const ctx = animate(
       el(),
-      [
-        { translate: `translate(0px, 10px)` },
-        { translate: sv`translate(${x}px, ${y}px)` },
-      ],
+      [{ translate: `translate(0px, 10px)` }, { translate: sv`translate(${x}px, ${y}px)` }],
       { duration: 10 },
     )
 
@@ -301,10 +296,7 @@ describe('animate', () => {
     const y = spring(20)
     const ctx = animate(
       el(),
-      [
-        { translate: `translate(0px, 10%)` },
-        { translate: sv`translate(${x}px, ${y}%)` },
-      ],
+      [{ translate: `translate(0px, 10%)` }, { translate: sv`translate(${x}px, ${y}%)` }],
       { duration: 10 },
     )
 

--- a/test/core/controller.test.ts
+++ b/test/core/controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+
 import { createAnimateController } from '../../src/core'
 
 function el(): HTMLElement {

--- a/test/core/spring.test.ts
+++ b/test/core/spring.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+
 import {
   createSpring,
   springSettlingDuration,

--- a/test/core/style.test.ts
+++ b/test/core/style.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+
 import {
   completeParsedStyleUnit,
   interpolateParsedStyle,
@@ -301,8 +302,6 @@ describe('stringifyInterpolatedStyle', () => {
       },
       ['100 * exp(3)', '100 * exp(4)'],
     )
-    expect(actual).toBe(
-      'translate(calc(1px * (100 * exp(3))), calc(1% * (100 * exp(4))))',
-    )
+    expect(actual).toBe('translate(calc(1px * (100 * exp(3))), calc(1% * (100 * exp(4))))')
   })
 })

--- a/test/core/time.test.ts
+++ b/test/core/time.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+
 import { wait } from '../../src/core/time'
 
 describe('time', () => {

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+
 import { zip } from '../../src/core/utils'
 
 describe('zip', () => {

--- a/test/vue/SpringTransition.test.ts
+++ b/test/vue/SpringTransition.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vitest } from 'vitest'
-import SpringTransition from '../../src/vue/SpringTransition'
-import { AnimationController } from '../../src/core'
 import { createApp, nextTick } from 'vue'
+
+import { AnimationController } from '../../src/core'
+import SpringTransition from '../../src/vue/SpringTransition'
 
 let mockController: Record<keyof AnimationController<any>, any> | undefined
 
@@ -11,9 +12,7 @@ vitest.mock('../../src/core/controller', async () => {
   return {
     ...module,
     createAnimateController: (...args: any[]) => {
-      const controller = (mockController = module.createAnimateController(
-        ...args,
-      ))
+      const controller = (mockController = module.createAnimateController(...args))
       vitest.spyOn(controller, 'setStyle')
       vitest.spyOn(controller, 'setOptions')
       return controller
@@ -54,10 +53,7 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
   })
 
@@ -143,10 +139,7 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = false
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 1 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
 
@@ -172,10 +165,7 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
 
     mockController?.setStyle.mockClear()
@@ -207,10 +197,7 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = false
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 1 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 })
 
     mockController?.setStyle.mockClear()
@@ -242,10 +229,7 @@ describe('SpringTransition', () => {
     const vm: any = app.mount(root)
     vm.isShow = true
     await nextTick()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
 
     mockController?.setStyle.mockClear()
@@ -257,10 +241,7 @@ describe('SpringTransition', () => {
     mockController?.setStyle.mockClear()
     await wait(20)
     expect(mockController?.setStyle).toHaveBeenCalledOnce()
-    expect(mockController?.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
   })
 
   test('trigger before-enter event before setting style', () => {

--- a/test/vue/SpringTransitionGroup.test.ts
+++ b/test/vue/SpringTransitionGroup.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test, vitest } from 'vitest'
 import { createApp, nextTick } from 'vue'
-import SpringTransitionGroup from '../../src/vue/SpringTransitionGroup'
-import { scKey } from '../../src/vue/SpringTransition'
+
 import { AnimationController } from '../../src/core'
+import { scKey } from '../../src/vue/SpringTransition'
+import SpringTransitionGroup from '../../src/vue/SpringTransitionGroup'
 
 vitest.mock('../../src/core/controller', async () => {
   const module = await vitest.importActual<any>('../../src/core/controller')
@@ -50,10 +51,7 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller: AnimationController<any> = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
   })
 
@@ -148,10 +146,7 @@ describe('SpringTransitionGroup', () => {
     vm.list = []
     await nextTick()
 
-    expect(el[scKey].setStyle).toHaveBeenCalledWith(
-      { opacity: 1 },
-      { animate: false },
-    )
+    expect(el[scKey].setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
     expect(el[scKey].setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
 
@@ -179,10 +174,7 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
     controller.setStyle.mockClear()
 
@@ -218,10 +210,7 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith(
-      { opacity: 1 },
-      { animate: false },
-    )
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
     controller.setStyle.mockClear()
 
@@ -256,20 +245,14 @@ describe('SpringTransitionGroup', () => {
     await nextTick()
 
     const controller = vm.$refs.els[0][scKey]
-    expect(controller.setStyle).toHaveBeenCalledWith(
-      { opacity: 1 },
-      { animate: false },
-    )
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
     expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
     controller.setStyle.mockClear()
 
     await wait(20)
 
     expect(controller.setStyle).toHaveBeenCalledTimes(1)
-    expect(controller.setStyle).toHaveBeenCalledWith(
-      { opacity: 0.5 },
-      { animate: false },
-    )
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0.5 }, { animate: false })
   })
 
   test('force finish enter animation when move processing is triggered', async () => {
@@ -388,10 +371,7 @@ describe('SpringTransitionGroup', () => {
           afterEnter() {
             try {
               const controller = this.$refs.els[0][scKey]
-              expect(controller.setStyle).toHaveBeenCalledWith(
-                { opacity: 0 },
-                { animate: false },
-              )
+              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
               expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
               resolve()
             } catch (e) {
@@ -498,10 +478,7 @@ describe('SpringTransitionGroup', () => {
           afterLeave() {
             try {
               const controller = el[scKey]
-              expect(controller.setStyle).toHaveBeenCalledWith(
-                { opacity: 1 },
-                { animate: false },
-              )
+              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
               expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
               resolve()
             } catch (e) {

--- a/test/vue/directives.test.ts
+++ b/test/vue/directives.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vitest } from 'vitest'
 import { createApp, nextTick, ref } from 'vue'
-import { springDirectives } from '../../src/vue/directives'
+
 import { AnimationController } from '../../src/core'
+import { springDirectives } from '../../src/vue/directives'
 
 let mockController: Record<keyof AnimationController<any>, any>
 
@@ -11,9 +12,7 @@ vitest.mock('../../src/core/controller', async () => {
   return {
     ...module,
     createAnimateController: (...args: any[]) => {
-      const controller = (mockController = module.createAnimateController(
-        ...args,
-      ))
+      const controller = (mockController = module.createAnimateController(...args))
       vitest.spyOn(controller, 'setStyle')
       vitest.spyOn(controller, 'setOptions')
       return controller
@@ -38,8 +37,7 @@ describe('directives', () => {
   test('set both style and options', async () => {
     const root = document.createElement('div')
     const app = createApp({
-      template:
-        '<div v-spring-style="{ opacity: 0 }" v-spring-options="{ bounce: 0.2 }"></div>',
+      template: '<div v-spring-style="{ opacity: 0 }" v-spring-options="{ bounce: 0.2 }"></div>',
     })
     app.use(springDirectives).mount(root)
     expect(mockController.setOptions).toHaveBeenCalledWith({ bounce: 0.2 })
@@ -52,8 +50,7 @@ describe('directives', () => {
 
     const root = document.createElement('div')
     const app = createApp({
-      template:
-        '<div v-spring-style="{ opacity }" v-spring-options="{ bounce }"></div>',
+      template: '<div v-spring-style="{ opacity }" v-spring-options="{ bounce }"></div>',
       setup() {
         return {
           opacity,
@@ -76,8 +73,7 @@ describe('directives', () => {
   test('set style property with lower camel case', () => {
     const root = document.createElement('div')
     const app = createApp({
-      template:
-        "<div v-spring-style=\"{ width: '100%', backgroundColor: '#fff' }\"></div>",
+      template: "<div v-spring-style=\"{ width: '100%', backgroundColor: '#fff' }\"></div>",
     })
     const vm = app.use(springDirectives).mount(root)
     expect(vm.$el.style.width).toBe('100%')

--- a/test/vue/spring-element.test.ts
+++ b/test/vue/spring-element.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, vitest } from 'vitest'
 import { createApp, nextTick, ref } from 'vue'
-import { spring } from '../../src/vue/spring-element'
+
 import { AnimationController } from '../../src/core'
+import { spring } from '../../src/vue/spring-element'
 
 let mockController: Record<keyof AnimationController<any>, any>
 
@@ -11,9 +12,7 @@ vitest.mock('../../src/core/controller', async () => {
   return {
     ...module,
     createAnimateController: (...args: any[]) => {
-      const controller = (mockController = module.createAnimateController(
-        ...args,
-      ))
+      const controller = (mockController = module.createAnimateController(...args))
       vitest.spyOn(controller, 'setStyle')
       vitest.spyOn(controller, 'setOptions')
       return controller
@@ -90,10 +89,7 @@ describe('Spring Element', () => {
       disabled: false,
       inferVelocity: true,
     })
-    expect(mockController.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: true },
-    )
+    expect(mockController.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: true })
   })
 
   test('disable animation when disabled prop is true', async () => {
@@ -121,10 +117,7 @@ describe('Spring Element', () => {
 
     vm.springStyle.opacity = 0
     await nextTick()
-    expect(mockController.setStyle).toHaveBeenCalledWith(
-      { opacity: 0 },
-      { animate: false },
-    )
+    expect(mockController.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
     expect(vm.$el.style.opacity).toBe('0')
   })
 
@@ -155,10 +148,7 @@ describe('Spring Element', () => {
 
     await nextTick()
 
-    expect(mockController.setStyle).toHaveBeenCalledWith(
-      { height: '100px' },
-      { animate: true },
-    )
+    expect(mockController.setStyle).toHaveBeenCalledWith({ height: '100px' }, { animate: true })
     expect(vm.$el.style.height).toBe('100px')
   })
 

--- a/test/vue/spring-value.test.ts
+++ b/test/vue/spring-value.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test, vitest } from 'vitest'
 import { createApp, nextTick, ref, watchEffect } from 'vue'
+
+import { AnimationController } from '../../src/core'
+import { sv } from '../../src/core/spring-value'
 import { spring } from '../../src/vue/spring-element'
 import { springComputed, springValue } from '../../src/vue/spring-value'
-import { sv } from '../../src/core/spring-value'
-import { AnimationController } from '../../src/core'
 
 let mockController: Record<keyof AnimationController<any>, any>
 
@@ -13,9 +14,7 @@ vitest.mock('../../src/core/controller', async () => {
   return {
     ...module,
     createAnimateController: (...args: any[]) => {
-      const controller = (mockController = module.createAnimateController(
-        ...args,
-      ))
+      const controller = (mockController = module.createAnimateController(...args))
       vitest.spyOn(controller, 'setStyle')
       vitest.spyOn(controller, 'setOptions')
       return controller

--- a/test/vue/use-spring.test.ts
+++ b/test/vue/use-spring.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'vitest'
-import { useSpring } from '../../src/vue/use-spring'
 import { EffectScope, effectScope, nextTick, ref } from 'vue'
+
+import { useSpring } from '../../src/vue/use-spring'
 
 describe('useSpring', () => {
   let scope: EffectScope | undefined

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
+import fs from 'node:fs'
+
+import vue from '@vitejs/plugin-vue'
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import fs from 'node:fs'
-import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
-import { defineConfig } from 'vite'
+
 import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [vue()],


### PR DESCRIPTION
## Summary

- Replace `prettier` (3.8.3) with `oxfmt` (0.50.0) as the project formatter
- Migrate prettier settings to `.oxfmtrc.json` via `oxfmt --migrate=prettier` (preserves `semi: false`, `singleQuote: true`, `printWidth: 80`, and the existing ignore patterns)
- Update `format` / `format:check` scripts to invoke `oxfmt`
- Reformat the codebase to match oxfmt's output

CI's existing `pnpm format:check` step continues to gate formatting; no workflow changes were needed.