### PR TITLE
chore: introduce oxlint

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Format Check
         run: pnpm format:check
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["oxc", "eslint", "typescript", "unicorn", "vitest", "vue"],
+  "options": {
+    "typeAware": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "test": "vitest",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
+    "lint": "oxlint --deny-warnings",
+    "lint:fix": "oxlint --fix",
     "demo": "vite build",
     "publish": "./scripts/publish.sh"
   },
@@ -46,6 +48,8 @@
     "conventional-changelog-cli": "5.0.0",
     "jsdom": "29.1.1",
     "oxfmt": "0.50.0",
+    "oxlint": "1.65.0",
+    "oxlint-tsgolint": "^0.22.1",
     "typescript": "6.0.3",
     "vite": "8.0.12",
     "vitest": "4.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       oxfmt:
         specifier: 0.50.0
         version: 0.50.0
+      oxlint:
+        specifier: 1.65.0
+        version: 1.65.0(oxlint-tsgolint@0.22.1)
+      oxlint-tsgolint:
+        specifier: ^0.22.1
+        version: 0.22.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -285,6 +291,158 @@ packages:
 
   '@oxfmt/binding-win32-x64-msvc@0.50.0':
     resolution: {integrity: sha512-BSE8D8KsvquMG9vU+Qt4qGuoOcZ36rxU5S6ZkHNguj+MlWkXWCBETnno3yJ9CfWvfCrbmieaN9LK6hdcdHNZ/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+    resolution: {integrity: sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
+    resolution: {integrity: sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
+    resolution: {integrity: sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.22.1':
+    resolution: {integrity: sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
+    resolution: {integrity: sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.22.1':
+    resolution: {integrity: sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.65.0':
+    resolution: {integrity: sha512-jDVaGNURT5pEA9qcabh6WusIoBNybOMMDPCx+EFt+gxo6rVvoUf0+73Xy5x81+ZrxU+ewk5uRBYifjy5pgkcnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.65.0':
+    resolution: {integrity: sha512-v0z80IWNA7c9RhUydq9YprBxCVZrQ6Ixls2tdxUC1F/1FFqSfa7xTX+EJf0mj6+BKRg2zWXqWfcbJUnETlLlIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.65.0':
+    resolution: {integrity: sha512-pL/mG/5gMzBwp1gdc5+Cwi87F9j3XRnPxHGyVj5Zd+dCEV5YkKt0L70PB3EGmEEHxgn4H+jnMS3xLuXs6mZW/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.65.0':
+    resolution: {integrity: sha512-jVTneaeuHtqTrKYnhrdH1buhnSorinvpy1sv43ayclfWx/e/DfdRWv+h1fopJcHQbYr5WMcZMmDvnfEBkPZ+1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.65.0':
+    resolution: {integrity: sha512-8lJQ7B6RloYDUhwVdbSpwT2eKsCN5KP1Scn18ly1tytCuhXhbs0nkfKHT4jWWZBJqmynWuzd+78bF7wILrj6pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.65.0':
+    resolution: {integrity: sha512-EgmZY+DeWhLLEnNl70/49j3ltA8I6X9kxMfexupWi2Vwfp6RonGsBaHtGoedLolaU37ne7eDUgoxa3CFB95GZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.65.0':
+    resolution: {integrity: sha512-OJMWmAYRVBCPPxnYr3j5sXRwHPh1bAuMlTStGco1Z8q3HkvSH4h+A10E9MiRNYmLhUuli5a2P5wmfj8cagiF5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.65.0':
+    resolution: {integrity: sha512-D8uNi50LsYKgS0vGARZDRx05TBZeSxAVdLGddSEqQLSU7xsiqdImHPEw55xq8sKA5rCc/4au/5uS7FQALWdLCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.65.0':
+    resolution: {integrity: sha512-IpbA8QGbwFehQhO+YaHwmoI81f93xvywpspf8HrdPCWOIeKwYfM1dhVhO4YKfZewTRRQEPY/JFjTOXTgkwhKrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.65.0':
+    resolution: {integrity: sha512-ZSe8HgaZdgyHSv2+/pTG68z10+OarB18CkFKQOhRs3lmmP/p2vuigedK2e9d0ztoG2DU/duJzhxXBSjy/492HQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.65.0':
+    resolution: {integrity: sha512-DcTERf++v6HyPHukKAr0JFTRqB+YeDEvqzRgNDMaz7jITPf+tlJIwRxodlAqoXMYhNVEZhXdQM5RAAYH8/oPuw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.65.0':
+    resolution: {integrity: sha512-xjhMwuFJwRh40NOBzol4gM5gqAa0xPCJU+GQLM6BydV8TbfkIA7JeyCFNhyfbE9Q/5EWcKYTx62R0cRcjP7DAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.65.0':
+    resolution: {integrity: sha512-lrWSXb8JzboPWYBG6Kunt/eemvjo2oCFXktShsm3yMToY7HjzKLjxh7CljSvGnnZH9oohNFHOKc9xYpGKCPm6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.65.0':
+    resolution: {integrity: sha512-A7xfghw250m4a1sPV+q44Mow2G5bhiC9FBvhAuIhJS6QovWnqzuL5AFQPEuwOB+PM4DhABkqxVa3Iwe3Y/nFlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.65.0':
+    resolution: {integrity: sha512-reqOun1+pWO3fW6cv7bsa8hHG0TN3t/82qPdaoJo90FwugXiMjKhZMChmH5Z01cFNRHmxN4+543Fy8478cM/iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.65.0':
+    resolution: {integrity: sha512-KQpqOb/juDBO0xyloDkVDhOVxDUgAfZ2OAAVq99TJScJDzT319xry1QzB9LQohV9QGnA7p6m/XATZkMXc84lwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.65.0':
+    resolution: {integrity: sha512-xfqcOc3nJFeAd1kDY4T9d3XeJIhr00twaaW0kOAzGPyUHkruXtNJv6zz1Ra9fRtSek5VpW2Yoj5AcwPIlT0ZiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.65.0':
+    resolution: {integrity: sha512-JV+pXm45p8sdgs3c7LOPAohW23optCNZETFOXUcjn6cS4PYZhEU/RI54Z5dHdMudab3nw7T48PZILthM+Q0COQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.65.0':
+    resolution: {integrity: sha512-D7L/oBbskLss21bYrRbFuIs81AiSQV+wRzwck54dOkHIlq2qu1xjLz8u6jCqGH8Fltk8bB5DLBpVhE7v/fA8XQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -819,6 +977,20 @@ packages:
       svelte:
         optional: true
 
+  oxlint-tsgolint@0.22.1:
+    resolution: {integrity: sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==}
+    hasBin: true
+
+  oxlint@1.65.0:
+    resolution: {integrity: sha512-ChUuE3Q7XnAbscvT4XLMsH7HFJmLgLVv9lu+RRgFL5wSXnDqUOzTp5IS8qWDBGd/ZDSzQ2tbX8fjAmijlGLC7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -1274,6 +1446,81 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.50.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.22.1':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.65.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.65.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.65.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.65.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.65.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.65.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.65.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.65.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.65.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.65.0':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0':
@@ -1796,6 +2043,38 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.50.0
       '@oxfmt/binding-win32-ia32-msvc': 0.50.0
       '@oxfmt/binding-win32-x64-msvc': 0.50.0
+
+  oxlint-tsgolint@0.22.1:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.22.1
+      '@oxlint-tsgolint/darwin-x64': 0.22.1
+      '@oxlint-tsgolint/linux-arm64': 0.22.1
+      '@oxlint-tsgolint/linux-x64': 0.22.1
+      '@oxlint-tsgolint/win32-arm64': 0.22.1
+      '@oxlint-tsgolint/win32-x64': 0.22.1
+
+  oxlint@1.65.0(oxlint-tsgolint@0.22.1):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.65.0
+      '@oxlint/binding-android-arm64': 1.65.0
+      '@oxlint/binding-darwin-arm64': 1.65.0
+      '@oxlint/binding-darwin-x64': 1.65.0
+      '@oxlint/binding-freebsd-x64': 1.65.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.65.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.65.0
+      '@oxlint/binding-linux-arm64-gnu': 1.65.0
+      '@oxlint/binding-linux-arm64-musl': 1.65.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.65.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.65.0
+      '@oxlint/binding-linux-riscv64-musl': 1.65.0
+      '@oxlint/binding-linux-s390x-gnu': 1.65.0
+      '@oxlint/binding-linux-x64-gnu': 1.65.0
+      '@oxlint/binding-linux-x64-musl': 1.65.0
+      '@oxlint/binding-openharmony-arm64': 1.65.0
+      '@oxlint/binding-win32-arm64-msvc': 1.65.0
+      '@oxlint/binding-win32-ia32-msvc': 1.65.0
+      '@oxlint/binding-win32-x64-msvc': 1.65.0
+      oxlint-tsgolint: 0.22.1
 
   parse-json@8.3.0:
     dependencies:

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -86,7 +86,7 @@ export function createAnimateController<Style extends Record<string, AnimateValu
       })
     }
 
-    return mapValues(next, (value) => new Array(value.values.length).fill(0))
+    return mapValues(next, (value) => Array.from<number>({ length: value.values.length }, () => 0))
   }
 
   function commitStaticStyle(parsed: Record<keyof Style, ParsedStyleValue>): void {
@@ -200,7 +200,7 @@ export function createAnimateController<Style extends Record<string, AnimateValu
     // Must store ctx to local variable because ctx in the callback of `then` can be
     // different from when the time onFinishCurrent
     const _ctx = ctx
-    _ctx.finishingPromise.then(() => {
+    void _ctx.finishingPromise.then(() => {
       fn({ stopped: _ctx.stoppedDuration !== undefined })
     })
   }
@@ -214,7 +214,7 @@ export function createAnimateController<Style extends Record<string, AnimateValu
     // Must store ctx to local variable because ctx in the callback of `then` can be
     // different from when the time onFinishCurrent
     const _ctx = ctx
-    _ctx.settlingPromise.then(() => {
+    void _ctx.settlingPromise.then(() => {
       fn({ stopped: _ctx.stoppedDuration !== undefined })
     })
   }
@@ -275,7 +275,7 @@ function updateValues<Style extends Record<string, ParsedStyleValue>>(
     return {
       wraps: value.wraps,
       units: value.units,
-      values: newValue ?? new Array(value.values.length).fill(0),
+      values: newValue ?? Array.from<number>({ length: value.values.length }, () => 0),
     }
   }) as Style
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -68,5 +68,5 @@ export function isCssMathAnimationSupported(): boolean {
 }
 
 export function forceReflow(): void {
-  document.body.offsetHeight
+  void document.body.offsetHeight
 }

--- a/src/vue/SpringTransition.ts
+++ b/src/vue/SpringTransition.ts
@@ -62,7 +62,7 @@ export function useTransitionHooks(
     })
 
     const ctx = controller.setStyle(props.springStyle)
-    ctx.finishingPromise.then(() => {
+    void ctx.finishingPromise.then(() => {
       if (ctx.stoppedDuration === undefined) {
         done()
       }
@@ -90,7 +90,7 @@ export function useTransitionHooks(
       ...props.springStyle,
       ...leaveTo,
     })
-    ctx.finishingPromise.then(() => {
+    void ctx.finishingPromise.then(() => {
       if (ctx.stoppedDuration === undefined) {
         done()
       }

--- a/src/vue/use-spring.ts
+++ b/src/vue/use-spring.ts
@@ -103,7 +103,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
     // onFinishCurrent(() => {
     //   ...
     // })
-    nextTick().then(() => {
+    void nextTick().then(() => {
       if (controller) {
         controller.onFinishCurrent(fn)
       } else {
@@ -113,7 +113,7 @@ export function useSpring<Style extends Record<string, AnimateValue>>(
   }
 
   function onSettleCurrent(fn: (data: { stopped: boolean }) => void): void {
-    nextTick().then(() => {
+    void nextTick().then(() => {
       if (controller) {
         controller.onSettleCurrent(fn)
       } else {

--- a/test/core/animate.test.ts
+++ b/test/core/animate.test.ts
@@ -97,30 +97,22 @@ describe('animate', () => {
     })
   })
 
-  test('ctx.finished = true after finishingPromise resolved', () => {
+  test('ctx.finished = true after finishingPromise resolved', async () => {
     const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 10,
     })
-    return new Promise<void>((resolve) => {
-      ctx.finishingPromise.then(() => {
-        expect(ctx.finished).toBe(true)
-        expect(ctx.settled).toBe(false)
-        resolve()
-      })
-    })
+    await ctx.finishingPromise
+    expect(ctx.finished).toBe(true)
+    expect(ctx.settled).toBe(false)
   })
 
-  test('ctx.settled = true after settlingPromise resolved', () => {
+  test('ctx.settled = true after settlingPromise resolved', async () => {
     const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 10,
     })
-    return new Promise<void>((resolve) => {
-      ctx.settlingPromise.then(() => {
-        expect(ctx.finished).toBe(true)
-        expect(ctx.settled).toBe(true)
-        resolve()
-      })
-    })
+    await ctx.settlingPromise
+    expect(ctx.finished).toBe(true)
+    expect(ctx.settled).toBe(true)
   })
 
   test('ctx.stop() makes finished and settled be true', () => {
@@ -132,20 +124,20 @@ describe('animate', () => {
     expect(ctx.settled).toBe(true)
   })
 
-  test('ctx.stop() force resolves finishingPromise', () => {
+  test('ctx.stop() force resolves finishingPromise', async () => {
     const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 60000,
     })
     ctx.stop()
-    return ctx.finishingPromise
+    await expect(ctx.finishingPromise).resolves.toBeUndefined()
   })
 
-  test('ctx.stop() force resolves settlingPromise', () => {
+  test('ctx.stop() force resolves settlingPromise', async () => {
     const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }], {
       duration: 60000,
     })
     ctx.stop()
-    return ctx.settlingPromise
+    await expect(ctx.settlingPromise).resolves.toBeUndefined()
   })
 
   test('SpringValue.current() reaches `to` after settled', () => {

--- a/test/core/style.test.ts
+++ b/test/core/style.test.ts
@@ -222,12 +222,10 @@ describe('completeParsedStyleUnit', () => {
     },
   ]
 
-  for (const { name, value, context, expected } of properties) {
-    test(name, () => {
-      const actual = completeParsedStyleUnit(value, context)
-      expect(actual).toEqual(expected)
-    })
-  }
+  test.each(properties)('$name', ({ value, context, expected }) => {
+    const actual = completeParsedStyleUnit(value, context)
+    expect(actual).toEqual(expected)
+  })
 })
 
 describe('joinStyleValues', () => {

--- a/test/core/time.test.ts
+++ b/test/core/time.test.ts
@@ -15,7 +15,7 @@ describe('time', () => {
     const start = performance.now()
     const promise = wait(16)
 
-    vi.advanceTimersByTimeAsync(16)
+    await vi.advanceTimersByTimeAsync(16)
     await promise
 
     const end = performance.now()

--- a/test/vue/SpringTransition.test.ts
+++ b/test/vue/SpringTransition.test.ts
@@ -244,221 +244,215 @@ describe('SpringTransition', () => {
     expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
   })
 
-  test('trigger before-enter event before setting style', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger before-enter event before setting style', async () => {
+    const root = document.createElement('div')
+    let resolveBefore!: (controller: typeof mockController) => void
+    const beforeEntered = new Promise<typeof mockController>((resolve) => {
+      resolveBefore = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @before-enter="onBeforeEnter">
           <span v-show="isShow">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: false,
+        }
+      },
+      methods: {
+        onBeforeEnter() {
+          resolveBefore(mockController)
         },
-        data() {
-          return {
-            isShow: false,
-          }
-        },
-        methods: {
-          async onBeforeEnter() {
-            try {
-              expect(mockController).toBe(undefined)
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = true
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = true
+    const controllerAtEvent = await beforeEntered
+    expect(controllerAtEvent).toBe(undefined)
   })
 
-  test('trigger after-enter event after animation', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger after-enter event after animation', async () => {
+    const root = document.createElement('div')
+    let resolveAfter!: (el: HTMLElement) => void
+    const afterEntered = new Promise<HTMLElement>((resolve) => {
+      resolveAfter = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @after-enter="onAfterEnter" :duration="10">
           <span v-show="isShow" ref="el">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: false,
+        }
+      },
+      methods: {
+        onAfterEnter() {
+          resolveAfter(this.$refs.el as HTMLElement)
         },
-        data() {
-          return {
-            isShow: false,
-          }
-        },
-        methods: {
-          async onAfterEnter() {
-            try {
-              expect(mockController?.setStyle).toHaveBeenCalledWith(
-                { opacity: 0 },
-                { animate: false },
-              )
-              expect(mockController?.setStyle).toHaveBeenCalledWith({
-                opacity: 1,
-              })
-              expect(this.$refs.el.style.display).toBe('')
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = true
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = true
+    const el = await afterEntered
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 })
+    expect(el.style.display).toBe('')
   })
 
-  test('trigger enter-cancelled event on cancelling animation', () => {
-    return new Promise<void>(async (resolve) => {
-      const root = document.createElement('div')
+  test('trigger enter-cancelled event on cancelling animation', async () => {
+    const root = document.createElement('div')
+    let resolveCancelled!: () => void
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @enter-cancelled="onEnterCancelled">
           <span v-show="isShow">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: false,
+        }
+      },
+      methods: {
+        onEnterCancelled() {
+          resolveCancelled()
         },
-        data() {
-          return {
-            isShow: false,
-          }
-        },
-        methods: {
-          onEnterCancelled() {
-            resolve()
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = true
-      await nextTick()
-      vm.isShow = false
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = true
+    await nextTick()
+    vm.isShow = false
+    await cancelled
+    expect(mockController?.setStyle).toHaveBeenCalled()
   })
 
-  test('trigger before-leave event before setting style', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger before-leave event before setting style', async () => {
+    const root = document.createElement('div')
+    let resolveBefore!: (controller: typeof mockController) => void
+    const beforeLeft = new Promise<typeof mockController>((resolve) => {
+      resolveBefore = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :spring-style="{ opacity: 1 }" :leave-to="{ opacity: 0 }" @before-leave="onBeforeLeave">
           <span v-show="isShow">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: true,
+        }
+      },
+      methods: {
+        onBeforeLeave() {
+          resolveBefore(mockController)
         },
-        data() {
-          return {
-            isShow: true,
-          }
-        },
-        methods: {
-          async onBeforeLeave() {
-            try {
-              expect(mockController).toBe(undefined)
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = false
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = false
+    const controllerAtEvent = await beforeLeft
+    expect(controllerAtEvent).toBe(undefined)
   })
 
-  test('trigger after-leave event after animation', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger after-leave event after animation', async () => {
+    const root = document.createElement('div')
+    let resolveAfter!: (el: HTMLElement) => void
+    const afterLeft = new Promise<HTMLElement>((resolve) => {
+      resolveAfter = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :spring-style="{ opacity: 1 }" :leave-to="{ opacity: 0 }" @after-leave="onAfterLeave" :duration="10">
           <span v-show="isShow" ref="el">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: true,
+        }
+      },
+      methods: {
+        onAfterLeave() {
+          resolveAfter(this.$refs.el as HTMLElement)
         },
-        data() {
-          return {
-            isShow: true,
-          }
-        },
-        methods: {
-          async onAfterLeave() {
-            try {
-              expect(mockController?.setStyle).toHaveBeenCalledWith(
-                { opacity: 1 },
-                { animate: false },
-              )
-              expect(mockController?.setStyle).toHaveBeenCalledWith({
-                opacity: 0,
-              })
-              expect(this.$refs.el.style.display).toBe('none')
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = false
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = false
+    const el = await afterLeft
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
+    expect(mockController?.setStyle).toHaveBeenCalledWith({ opacity: 0 })
+    expect(el.style.display).toBe('none')
   })
 
-  test('trigger leave-cancelled event on cancelling animation', () => {
-    return new Promise<void>(async (resolve) => {
-      const root = document.createElement('div')
+  test('trigger leave-cancelled event on cancelling animation', async () => {
+    const root = document.createElement('div')
+    let resolveCancelled!: () => void
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition :spring-style="{ opacity: 1 }" :leave-to="{ opacity: 0 }" @leave-cancelled="onLeaveCancelled">
           <span v-show="isShow">Hello</span>
         </spring-transition>
       `,
-        components: {
-          SpringTransition,
+      components: {
+        SpringTransition,
+      },
+      data() {
+        return {
+          isShow: true,
+        }
+      },
+      methods: {
+        onLeaveCancelled() {
+          resolveCancelled()
         },
-        data() {
-          return {
-            isShow: true,
-          }
-        },
-        methods: {
-          onLeaveCancelled() {
-            resolve()
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = false
-      await nextTick()
-      vm.isShow = true
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = false
+    await nextTick()
+    vm.isShow = true
+    await cancelled
+    expect(mockController?.setStyle).toHaveBeenCalled()
   })
 })

--- a/test/vue/SpringTransitionGroup.test.ts
+++ b/test/vue/SpringTransitionGroup.test.ts
@@ -313,217 +313,218 @@ describe('SpringTransitionGroup', () => {
     expect(el[scKey].stop).not.toHaveBeenCalled()
   })
 
-  test('trigger before-enter event before setting style', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger before-enter event before setting style', async () => {
+    const root = document.createElement('div')
+    let resolveBefore!: (els: any[]) => void
+    const beforeEntered = new Promise<any[]>((resolve) => {
+      resolveBefore = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @before-enter="beforeEnter">
           <div v-for="item of list" key="item" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: [],
+        }
+      },
+      methods: {
+        beforeEnter() {
+          resolveBefore(this.$refs.els ?? [])
         },
-        data() {
-          return {
-            list: [],
-          }
-        },
-        methods: {
-          beforeEnter() {
-            try {
-              const els = this.$refs.els ?? []
-              expect(els.length).toBe(0)
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.list = ['a']
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.list = ['a']
+    const els = await beforeEntered
+    expect(els.length).toBe(0)
   })
 
-  test('trigger after-enter event after animation', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
+  test('trigger after-enter event after animation', async () => {
+    const root = document.createElement('div')
+    let resolveAfter!: (controller: any) => void
+    const afterEntered = new Promise<any>((resolve) => {
+      resolveAfter = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @after-enter="afterEnter" :duration="10">
           <div v-for="item of list" key="item" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: [],
+        }
+      },
+      methods: {
+        afterEnter() {
+          resolveAfter(this.$refs.els[0][scKey])
         },
-        data() {
-          return {
-            list: [],
-          }
-        },
-        methods: {
-          afterEnter() {
-            try {
-              const controller = this.$refs.els[0][scKey]
-              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
-              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.list = ['a']
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.list = ['a']
+    const controller = await afterEntered
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 }, { animate: false })
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 })
   })
 
-  test('trigger enter-cancelled event on cancelling animation', () => {
-    return new Promise<void>(async (resolve) => {
-      const root = document.createElement('div')
+  test('trigger enter-cancelled event on cancelling animation', async () => {
+    const root = document.createElement('div')
+    let resolveCancelled!: () => void
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :enter-from="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @enter-cancelled="enterCancelled">
           <div v-for="item of list" key="item" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: [],
+        }
+      },
+      methods: {
+        enterCancelled() {
+          resolveCancelled()
         },
-        data() {
-          return {
-            list: [],
-          }
-        },
-        methods: {
-          enterCancelled() {
-            resolve()
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.list = ['a']
-      await nextTick()
-      vm.list = []
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.list = ['a']
+    await nextTick()
+    vm.list = []
+    await cancelled
+    expect(vm.list).toEqual([])
   })
 
-  test('trigger before-leave event before setting style', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
-      let el: any
+  test('trigger before-leave event before setting style', async () => {
+    const root = document.createElement('div')
+    let el: any
+    let resolveBefore!: (controller: any) => void
+    const beforeLeft = new Promise<any>((resolve) => {
+      resolveBefore = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :leave-to="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @before-leave="beforeLeave">
           <div v-for="item of list" key="item" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: ['a'],
+        }
+      },
+      methods: {
+        beforeLeave() {
+          resolveBefore(el[scKey])
         },
-        data() {
-          return {
-            list: ['a'],
-          }
-        },
-        methods: {
-          beforeLeave() {
-            try {
-              expect(el[scKey]).toBe(undefined)
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      el = vm.$refs.els[0]
-      vm.list = []
+      },
     })
+
+    const vm: any = app.mount(root)
+    el = vm.$refs.els[0]
+    vm.list = []
+    const controllerAtEvent = await beforeLeft
+    expect(controllerAtEvent).toBe(undefined)
   })
 
-  test('trigger after-leave event after animation', () => {
-    return new Promise<void>((resolve, reject) => {
-      const root = document.createElement('div')
-      let el: any
+  test('trigger after-leave event after animation', async () => {
+    const root = document.createElement('div')
+    let resolveAfter!: () => void
+    const afterLeft = new Promise<void>((resolve) => {
+      resolveAfter = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :leave-to="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @after-leave="afterLeave" :duration="10">
           <div v-for="item of list" key="item" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: ['a'],
+        }
+      },
+      methods: {
+        afterLeave() {
+          resolveAfter()
         },
-        data() {
-          return {
-            list: ['a'],
-          }
-        },
-        methods: {
-          afterLeave() {
-            try {
-              const controller = el[scKey]
-              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
-              expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
-              resolve()
-            } catch (e) {
-              reject(e)
-            }
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      el = vm.$refs.els[0]
-      vm.list = []
+      },
     })
+
+    const vm: any = app.mount(root)
+    const el = vm.$refs.els[0]
+    vm.list = []
+    await afterLeft
+    const controller = el[scKey]
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 1 }, { animate: false })
+    expect(controller.setStyle).toHaveBeenCalledWith({ opacity: 0 })
   })
 
-  test('trigger leave-cancelled event on cancelling animation', () => {
-    return new Promise<void>(async (resolve) => {
-      const root = document.createElement('div')
+  test('trigger leave-cancelled event on cancelling animation', async () => {
+    const root = document.createElement('div')
+    let resolveCancelled!: () => void
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve
+    })
 
-      const app = createApp({
-        template: `
+    const app = createApp({
+      template: `
         <spring-transition-group :leave-to="{ opacity: 0 }" :spring-style="{ opacity: 1 }" @leave-cancelled="leaveCancelled">
           <div v-for="item of list" key="item" v-show="isShow" ref="els">{{ item }}</div>
         </spring-transition-group>
       `,
-        components: {
-          SpringTransitionGroup,
+      components: {
+        SpringTransitionGroup,
+      },
+      data() {
+        return {
+          list: ['a'],
+          isShow: true,
+        }
+      },
+      methods: {
+        leaveCancelled() {
+          resolveCancelled()
         },
-        data() {
-          return {
-            list: ['a'],
-            isShow: true,
-          }
-        },
-        methods: {
-          leaveCancelled() {
-            resolve()
-          },
-        },
-      })
-
-      const vm: any = app.mount(root)
-      vm.isShow = false
-      await nextTick()
-      vm.isShow = true
+      },
     })
+
+    const vm: any = app.mount(root)
+    vm.isShow = false
+    await nextTick()
+    vm.isShow = true
+    await cancelled
+    expect(vm.isShow).toBe(true)
   })
 })

--- a/test/vue/spring-element.test.ts
+++ b/test/vue/spring-element.test.ts
@@ -154,8 +154,8 @@ describe('Spring Element', () => {
 
   function mountWithEvents(template: string, setupExtra?: () => any) {
     const root = document.createElement('div')
-    const finish = vitest.fn()
-    const settle = vitest.fn()
+    const finish = vitest.fn<(data: { stopped: boolean }) => void>()
+    const settle = vitest.fn<(data: { stopped: boolean }) => void>()
     const app = createApp({
       template,
       components: {
@@ -167,7 +167,7 @@ describe('Spring Element', () => {
           springStyle,
           onFinish: finish,
           onSettle: settle,
-          ...(setupExtra?.() ?? {}),
+          ...setupExtra?.(),
         }
       },
     })


### PR DESCRIPTION
## Summary

- Add `oxlint` (with type-aware checks via `oxlint-tsgolint`) alongside the existing `oxfmt` setup.
- Wire it into CI as a `Lint` step in `build-and-test.yml`, with `lint` / `lint:fix` scripts in `package.json` and a `.oxlintrc.json` enabling the `oxc`, `eslint`, `typescript`, `unicorn`, `vitest`, and `vue` plugin sets.
- Fix the warnings the default ruleset surfaces: `void`-prefix fire-and-forget promises in `controller.ts` / `SpringTransition.ts` / `use-spring.ts`, swap `new Array(n).fill(0)` for `Array.from`, type the `vitest.fn()` helpers, and tighten a few minor expressions.
- Rewrite the event-driven `SpringTransition` / `SpringTransitionGroup` / `animate` tests to the canonical async/await form (snapshot state inside the event handler, await, then assert) so `vitest/expect-expect` sees the assertions; convert the parameterized `completeParsedStyleUnit` suite to `test.each` for `vitest/valid-title`.