### PR TITLE
ci: add brotli size to bundle size report

### DIFF
--- a/scripts/bundle-size-report.ts
+++ b/scripts/bundle-size-report.ts
@@ -4,6 +4,7 @@ interface Sizes {
   bundled: number
   minified: number
   gzipped: number
+  brotli: number
 }
 
 const [, , basePath, headPath] = process.argv
@@ -43,6 +44,7 @@ const lines = [
   row('Bundled', 'bundled'),
   row('Minified', 'minified'),
   row('Minified + Gzipped', 'gzipped'),
+  row('Minified + Brotli', 'brotli'),
 ]
 
 const baseSha = process.env.BASE_SHA

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -1,7 +1,7 @@
 import { readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { gzipSync } from 'node:zlib'
+import { brotliCompressSync, constants, gzipSync } from 'node:zlib'
 
 import { build } from 'vite'
 
@@ -33,6 +33,11 @@ process.stdout.write(
       bundled,
       minified: minifiedBuf.length,
       gzipped: gzipSync(minifiedBuf).length,
+      brotli: brotliCompressSync(minifiedBuf, {
+        params: {
+          [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY,
+        },
+      }).length,
     },
     null,
     2,


### PR DESCRIPTION
## Summary
- Measure max-quality Brotli size of the minified bundle in `scripts/bundle-size.ts` alongside the existing gzip measurement.
- Render a "Minified + Brotli" row in the PR bundle size comment.