### PR TITLE
chore: split tsconfig into per-target project references

### DIFF
--- a/demo/toggle/App.vue
+++ b/demo/toggle/App.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 import { spring } from '../../src/vue'

--- a/demo/transition-group/App.vue
+++ b/demo/transition-group/App.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 import { SpringTransitionGroup } from '../../src/vue'
@@ -41,7 +41,7 @@ function onShuffle() {
     }"
     :duration="800"
     :bounce="0"
-    @before-leave="(el) => (el.style.position = 'absolute')"
+    @before-leave="(el) => ((el as HTMLElement).style.position = 'absolute')"
   >
     <li v-for="item of list" :key="item">{{ item }}</li>
   </SpringTransitionGroup>

--- a/demo/transition/App.vue
+++ b/demo/transition/App.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 import { SpringTransition } from '../../src/vue'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --config vite.lib.config.ts",
-    "dts": "vue-tsc",
+    "dts": "vue-tsc -p tsconfig.lib.json",
     "typecheck": "vitest --typecheck",
     "test": "vitest",
     "format": "oxfmt",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "include": ["../src/**/*.ts", "**/*.ts"]
-}

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "rootDir": "demo",
+    "types": ["vite/client"],
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.demo.tsbuildinfo"
+  },
+  "include": ["demo/**/*.ts", "demo/**/*.vue"],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -4,7 +4,6 @@
     "composite": true,
     "noEmit": true,
     "rootDir": "demo",
-    "types": ["vite/client"],
     "tsBuildInfoFile": "node_modules/.tmp/tsconfig.demo.tsbuildinfo"
   },
   "include": ["demo/**/*.ts", "demo/**/*.vue"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,8 @@
 {
-  "compilerOptions": {
-    "target": "es2025",
-    "useDefineForClassFields": true,
-    "module": "esnext",
-    "lib": ["ES2025", "DOM"],
-    "types": [],
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "rootDir": "src",
-    "declarationDir": "types",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true
-  },
-  "include": ["src/**/*.ts"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.demo.json" }
+  ]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.lib.tsbuildinfo",
+    "target": "es2025",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "lib": ["ES2025", "DOM"],
+    "types": [],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "rootDir": "src",
+    "declarationDir": "types",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -6,7 +6,7 @@
     "useDefineForClassFields": true,
     "module": "esnext",
     "lib": ["ES2025", "DOM"],
-    "types": [],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": true,
+    "rootDir": "test",
+    "tsBuildInfoFile": "node_modules/.tmp/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["test/**/*.ts"],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     setupFiles: ['./test/setup-waapi.ts'],
     typecheck: {
       checker: 'vue-tsc',
+      tsconfig: './tsconfig.test.json',
     },
   },
 })


### PR DESCRIPTION
## Summary
- Collect all tsconfig files into the repository root and split into per-target project references: `tsconfig.json` (base), `tsconfig.lib.json` (library source), `tsconfig.test.json` (tests), and a new `tsconfig.demo.json` for the demo directory.
- Wire `dts` to `vue-tsc -p tsconfig.lib.json` and point vitest's typecheck at `tsconfig.test.json`.
- Convert the remaining JS `<script setup>` blocks in `demo/toggle`, `demo/transition`, and `demo/transition-group` to `lang="ts"` so the demo target type-checks cleanly under the new config.
- Drop `src/vite-env.d.ts` in favor of declaring `vite/client` through `tsconfig.lib.json`'s `types` option.