### PR TITLE
feat: resolve mismatched units to px for animation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,9 @@
         <a href="./picker/">Picker</a>
       </li>
       <li>
+        <a href="./unit-mismatch/">Unit Mismatch</a>
+      </li>
+      <li>
         <a href="./transition/">SpringTransition</a>
       </li>
       <li>

--- a/demo/unit-mismatch/App.vue
+++ b/demo/unit-mismatch/App.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+import { spring } from '../../src/vue'
+
+const flipped = ref(false)
+
+let timer: ReturnType<typeof setInterval> | undefined
+
+onMounted(() => {
+  timer = setInterval(() => {
+    flipped.value = !flipped.value
+  }, 2000)
+})
+
+onUnmounted(() => {
+  clearInterval(timer)
+})
+</script>
+
+<template>
+  <h1>Unit Mismatch Demo</h1>
+  <button type="button" class="toggle" @click="flipped = !flipped">Toggle</button>
+
+  <section>
+    <h2>width: 10rem ↔ 300px</h2>
+    <div class="track">
+      <spring.div
+        class="box"
+        :spring-style="{ width: flipped ? '300px' : '10rem' }"
+        :duration="800"
+        :bounce="0.3"
+      />
+    </div>
+  </section>
+
+  <section>
+    <h2>width: 50% ↔ 300px</h2>
+    <div class="track">
+      <spring.div
+        class="box"
+        :spring-style="{ width: flipped ? '300px' : '50%' }"
+        :duration="800"
+        :bounce="0.3"
+      />
+    </div>
+  </section>
+
+  <section>
+    <h2>padding: 10px 1rem ↔ 40px 64px</h2>
+    <div class="track">
+      <spring.div
+        class="box-padded"
+        :spring-style="{ padding: flipped ? '40px 64px' : '10px 1rem' }"
+        :duration="800"
+        :bounce="0.3"
+        >●</spring.div
+      >
+    </div>
+  </section>
+
+  <section>
+    <h2>font-size: 1em ↔ 48px</h2>
+    <div class="track">
+      <spring.div
+        class="box-text"
+        :spring-style="{ fontSize: flipped ? '48px' : '1em' }"
+        :duration="800"
+        :bounce="0.3"
+        >Aa</spring.div
+      >
+    </div>
+  </section>
+</template>
+
+<style scoped>
+h1 {
+  margin: 0 0 0.5rem;
+}
+
+h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+code {
+  background: #f1f1f1;
+  padding: 0 0.25em;
+  border-radius: 3px;
+}
+
+.toggle {
+  margin-bottom: 1.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+section {
+  margin-bottom: 1.5rem;
+}
+
+.track {
+  border: 1px dashed #bbb;
+  padding: 0.5rem;
+  background: #fafafa;
+  /* Anchor for `%` resolution: width: 50% resolves against this 400px width. */
+  width: 400px;
+}
+
+.box {
+  height: 30px;
+  background: #259902;
+  border-radius: 4px;
+}
+
+.box-padded {
+  display: inline-block;
+  background: #2566e3;
+  color: white;
+  border-radius: 4px;
+}
+
+.box-text {
+  display: inline-block;
+  font-weight: 600;
+  color: #aa2266;
+}
+</style>

--- a/demo/unit-mismatch/index.html
+++ b/demo/unit-mismatch/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Unit Mismatch Demo</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 1.5rem;
+        max-width: 720px;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/demo/unit-mismatch/index.ts
+++ b/demo/unit-mismatch/index.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/src/core/animate.ts
+++ b/src/core/animate.ts
@@ -635,7 +635,7 @@ function resolveSide(
   }
 
   // Check resolved unit. Do not complete if the target slot's units are not px.
-  const resolvedAsPx = resolved.units.every((u, i) => !idxSet.has(i) || u == 'px')
+  const resolvedAsPx = resolved.units.every((u, i) => !idxSet.has(i) || u === 'px')
   if (!resolvedAsPx) {
     return undefined
   }

--- a/src/core/animate.ts
+++ b/src/core/animate.ts
@@ -140,6 +140,11 @@ export function animate<
 
   // Attach animation info to every slot's SpringComputed.
   for (const key in slots) {
+    const [from, to] = resolvedFromTo[key]!
+    // The unit each slot is actually rendered in.
+    // so a captured live value can be tagged with its resolved unit.
+    const renderUnits = completeParsedStyleUnit(to, from).units
+
     slots[key]!.forEach((slot, slotIndex) => {
       const v = inputValues[key]?.[slotIndex]
       if (!v) return
@@ -151,6 +156,7 @@ export function animate<
         startTime,
         duration,
         ctx,
+        unit: renderUnits[slotIndex] ?? '',
       }
       attachSpringValue(slot, attachment)
       const fromSlot = fromSlots[key]?.[slotIndex]

--- a/src/core/animate.ts
+++ b/src/core/animate.ts
@@ -100,6 +100,8 @@ export function animate<
     ]
   })
 
+  const resolvedFromTo = resolveUnitMismatches(target, parsedFromTo)
+
   const duration = options.duration ?? 1000
   const bounce = options.bounce ?? 0
 
@@ -108,7 +110,7 @@ export function animate<
     duration,
   })
 
-  const inputValues = groupInputValues(parsedFromTo, slotVelocities)
+  const inputValues = groupInputValues(resolvedFromTo, slotVelocities)
 
   const settlingDurationList = Object.values(inputValues).flatMap((values) => {
     return values.map(({ from, to, velocity }) => {
@@ -129,7 +131,7 @@ export function animate<
   const ctx = createContext({
     target,
     slots,
-    fromTo: parsedFromTo,
+    fromTo: resolvedFromTo,
     startTime,
     duration,
     settlingDuration,
@@ -163,13 +165,13 @@ export function animate<
   if (
     waapi &&
     isCssLinearTimingFunctionSupported() &&
-    canUseLinearTimingFunction(parsedFromTo, slotVelocities)
+    canUseLinearTimingFunction(resolvedFromTo, slotVelocities)
   ) {
     animations.push(
       ...animateWithPerPropertyEasing({
         target,
         spring,
-        fromTo: parsedFromTo,
+        fromTo: resolvedFromTo,
         inputValues,
         settlingDuration,
       }),
@@ -179,7 +181,7 @@ export function animate<
       ...animateWithProxyTimeVariable({
         target,
         spring,
-        fromTo: parsedFromTo,
+        fromTo: resolvedFromTo,
         inputValues,
         duration,
         settlingDuration,
@@ -189,7 +191,7 @@ export function animate<
     // Graceful degradation for environments without WAAPI / linear() / CSS math.
     animateWithRaf({
       target,
-      fromTo: parsedFromTo,
+      fromTo: resolvedFromTo,
       slots,
       ctx,
     })
@@ -550,4 +552,93 @@ function resolveMissingEntries(
   })
 
   return { fromInput, toInput }
+}
+
+/**
+ * For every slot where `from`/`to` mix `px` with another non-empty length unit,
+ * resolve the non-px side to a px value by writing a probe with the side's
+ * original `<value><unit>` per slot, reading the post-resolution string from
+ * `getComputedStyle`, and re-parsing. A slot is left unchanged if the resolved
+ * string doesn't share the same `wraps` structure and only `px` / empty units
+ * in the expected places — this is what filters out `transform` (matrix
+ * expansion), shorthand expansion, keyword residue, `%`-retaining contexts, and
+ * custom properties.
+ *
+ * Returns a new map with the resolved `from`/`to` pairs; the input is left
+ * untouched.
+ */
+function resolveUnitMismatches(
+  target: AnimationTarget,
+  parsedFromTo: Record<string, [ParsedStyleValue, ParsedStyleValue]>,
+): Record<string, [ParsedStyleValue, ParsedStyleValue]> {
+  return mapValues(parsedFromTo, ([from, to], key): [ParsedStyleValue, ParsedStyleValue] => {
+    if (from.values.length !== to.values.length) return [from, to]
+
+    const fromIndices: number[] = []
+    const toIndices: number[] = []
+
+    // Record value indices that needs value completion.
+    zip(from.units, to.units).forEach(([fu, tu], i) => {
+      if (fu === tu) return
+
+      if (fu === 'px') {
+        toIndices.push(i)
+      } else if (tu === 'px') {
+        fromIndices.push(i)
+      }
+    })
+
+    if (fromIndices.length === 0 && toIndices.length === 0) return [from, to]
+
+    const resolvedFrom =
+      fromIndices.length > 0 ? resolveSide(target, key, from, fromIndices) : undefined
+    const resolvedTo = toIndices.length > 0 ? resolveSide(target, key, to, toIndices) : undefined
+
+    return [resolvedFrom ?? from, resolvedTo ?? to]
+  })
+}
+
+function resolveSide(
+  target: AnimationTarget,
+  key: string,
+  source: ParsedStyleValue,
+  indices: number[],
+): ParsedStyleValue | undefined {
+  const idxSet = new Set(indices)
+  const probe = interpolateParsedStyle(source, source.values)
+
+  // Write the probe and read computed style, then write the original style back.
+  const savedInline = readStyle(target.style, key)
+  writeStyle(target, key, probe)
+  const computedStr = readStyle(getComputedStyle(target), key)
+  if (savedInline === '') {
+    clearStyle(target, key)
+  } else {
+    writeStyle(target, key, savedInline)
+  }
+
+  const resolved = parseStyleValue(computedStr)
+
+  // Compare the structures between resolved and source style value.
+  // Do not complete if the structures are mismatched.
+  if (resolved.values.length !== source.values.length) return undefined
+  if (resolved.wraps.length !== source.wraps.length) return undefined
+  const sameWraps = zip(resolved.wraps, source.wraps).every(([rw, sw]) => rw === sw)
+  if (!sameWraps) {
+    return undefined
+  }
+
+  // Check resolved unit. Do not complete if the target slot's units are not px.
+  const resolvedAsPx = resolved.units.every((u, i) => !idxSet.has(i) || u == 'px')
+  if (!resolvedAsPx) {
+    return undefined
+  }
+
+  const newValues = source.values.slice()
+  const newUnits = source.units.slice()
+  for (const i of indices) {
+    newValues[i] = resolved.values[i]!
+    newUnits[i] = 'px'
+  }
+  return { wraps: source.wraps, units: newUnits, values: newValues }
 }

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -54,12 +54,6 @@ export function createAnimateController<Style extends Record<string, AnimateValu
   // Pseudo context for initial state (before triggering animation)
   let ctx: AnimateContext | undefined
 
-  function liveRealValue(
-    slots: Record<keyof Style, SpringComputed[]>,
-  ): Record<keyof Style, number[]> {
-    return mapValues(slots, (s) => s.map((v) => v.current()))
-  }
-
   function liveRealVelocity(
     slots: Record<keyof Style, SpringComputed[]>,
   ): Record<keyof Style, number[]> {
@@ -104,7 +98,7 @@ export function createAnimateController<Style extends Record<string, AnimateValu
     }
 
     if (style) {
-      style = liveSlots ? updateValues(style, liveRealValue(liveSlots)) : style
+      style = liveSlots ? updateValues(style, liveSlots) : style
       ctx = createPseudoContext()
     }
 
@@ -163,7 +157,7 @@ export function createAnimateController<Style extends Record<string, AnimateValu
     // hand off to the new ones — those become the `from` side of the new
     // animation.
     if (ctx && !ctx.settled && liveSlots) {
-      prev = updateValues(prev, liveRealValue(liveSlots))
+      prev = updateValues(prev, liveSlots)
     }
 
     liveSlots = newSlots
@@ -268,14 +262,23 @@ function velocityFromHistory<Key extends keyof any>(
 
 function updateValues<Style extends Record<string, ParsedStyleValue>>(
   springValues: Style,
-  values: Record<keyof Style, number[]>,
+  slots: Record<keyof Style, SpringComputed[]>,
 ): Style {
   return mapValues(springValues, (value, key): ParsedStyleValue => {
-    const newValue = values[key]
+    const keySlots = slots[key]
+    if (!keySlots) {
+      return {
+        wraps: value.wraps,
+        units: value.units,
+        values: Array.from({ length: value.values.length }, () => 0),
+      }
+    }
+
+    // Read the live value and its resolved unit from each slot
     return {
       wraps: value.wraps,
-      units: value.units,
-      values: newValue ?? Array.from({ length: value.values.length }, () => 0),
+      units: value.units.map((unit, i) => keySlots[i]?.unit() ?? unit),
+      values: keySlots.map((s) => s.current()),
     }
   }) as Style
 }

--- a/src/core/spring-value.ts
+++ b/src/core/spring-value.ts
@@ -11,7 +11,7 @@ const SPRING_VALUE_BRAND: unique symbol = Symbol('springValue')
 
 /**
  * An animation info that is attached to a SpringValue.
- * When attached, a SpringValue returns its current value and velocity
+ * When attached, a SpringValue returns its current value, resolved unit and velocity
  * computed from the animation info instead of its own state.
  */
 export interface Attachment {
@@ -22,6 +22,7 @@ export interface Attachment {
   startTime: number
   duration: number
   ctx: { settled: boolean; stoppedDuration: number | undefined }
+  unit: string
 }
 
 function evaluateAttachmentValue(a: Attachment): number {
@@ -63,6 +64,12 @@ export interface SpringComputed {
   current(): number
   velocity(): number
   setVelocity(v: number): void
+
+  /**
+   * The resolved unit of the value `current()` returns while attached to an
+   * animation, or `undefined` when not attached.
+   */
+  unit(): string | undefined
 }
 
 /**
@@ -79,6 +86,7 @@ interface InternalSpring {
   current(): number
   velocity(): number
   setVelocity(v: number): void
+  unit(): string | undefined
 }
 
 export type SpringStyleValue = StyleValue<SpringComputed>
@@ -115,6 +123,10 @@ export function createSpringValue(
 
     velocity(): number {
       return obj._attachment ? evaluateAttachmentVelocity(obj._attachment) : velocity
+    },
+
+    unit(): string | undefined {
+      return obj._attachment?.unit
     },
 
     setVelocity(v: number): void {

--- a/test/core/animate.test.ts
+++ b/test/core/animate.test.ts
@@ -77,6 +77,46 @@ function mockComputedWhenInlineCleared(
   activeSpies.push(spy)
 }
 
+/**
+ * Spy on `getComputedStyle` so that, for the given `target`, the resolver
+ * function decides what to return for each property. The resolver receives
+ * the property name and the current inline value (the "probe" written by the
+ * caller). If it returns `undefined`, the real computed value is used.
+ */
+function mockComputedFromProbe(
+  target: HTMLElement,
+  resolve: (key: string, probe: string) => string | undefined,
+): void {
+  const real = globalThis.getComputedStyle
+
+  const spy = vitest
+    .spyOn(globalThis, 'getComputedStyle')
+    .mockImplementation((elt: Element, pseudo?: string | null) => {
+      const cs = real(elt, pseudo)
+      if (elt !== target) return cs
+
+      return new Proxy(cs, {
+        get(t, prop, receiver) {
+          if (prop === 'getPropertyValue') {
+            return (name: string) => {
+              const probe = target.style.getPropertyValue(name)
+              const override = resolve(name, probe)
+              return override ?? t.getPropertyValue(name)
+            }
+          }
+          if (typeof prop === 'string') {
+            const probe = ((target.style as any)[prop] ?? '') as string
+            const override = resolve(prop, probe)
+            if (override !== undefined) return override
+          }
+          return Reflect.get(t, prop, receiver)
+        },
+      }) as CSSStyleDeclaration
+    })
+
+  activeSpies.push(spy)
+}
+
 describe('animate', () => {
   test('ctx.finished and ctx.settled equal to false on start', () => {
     const ctx = animate(el(), [{ scale: 0 }, { scale: 10 }])
@@ -515,5 +555,163 @@ describe('animate', () => {
     ])
 
     await ctx.settlingPromise
+  })
+
+  test('resolves non-px `from` to px when `to` is px', () => {
+    const target = el()
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'width' && probe === '10rem') return '160px'
+      return undefined
+    })
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(target, [{ width: '10rem' }, { width: '300px' }], { duration: 10 })
+
+    expect(calls[0]?.keyframes).toEqual([{ width: '160px' }, { width: '300px' }])
+  })
+
+  test('resolves non-px `to` to px when `from` is px', () => {
+    const target = el()
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'width' && probe === '10rem') return '160px'
+      return undefined
+    })
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(target, [{ width: '300px' }, { width: '10rem' }], { duration: 10 })
+
+    expect(calls[0]?.keyframes).toEqual([{ width: '300px' }, { width: '160px' }])
+  })
+
+  test('resolves only the mixed-unit slot in a multi-slot value', () => {
+    const target = el()
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'padding' && probe === '10px 1rem') return '10px 16px'
+      return undefined
+    })
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(target, [{ padding: '10px 1rem' }, { padding: '20px 30px' }], { duration: 10 })
+
+    expect(calls[0]?.keyframes).toEqual([{ padding: '10px 16px' }, { padding: '20px 30px' }])
+  })
+
+  test('skips resolution when computed expands to a different wraps structure', () => {
+    const target = el()
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'transform' && probe === 'translate(1rem)') {
+        return 'matrix(1, 0, 0, 1, 16, 0)'
+      }
+      return undefined
+    })
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(target, [{ transform: 'translate(1rem)' }, { transform: 'translate(100px)' }], {
+      duration: 10,
+    })
+
+    expect(calls[0]?.keyframes).toEqual([
+      { transform: 'translate(1rem)' },
+      { transform: 'translate(100px)' },
+    ])
+  })
+
+  test('skips resolution for custom properties (computed echoes the inline unit)', () => {
+    const target = el()
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(target, [{ '--x': '1rem' }, { '--x': '100px' }], { duration: 10 })
+
+    expect(calls[0]?.keyframes).toEqual([{ '--x': '1rem' }, { '--x': '100px' }])
+  })
+
+  test('leaves matching-unit and both-non-px pairs untouched', () => {
+    const target = el()
+
+    // Spy to confirm getComputedStyle is not invoked when there's nothing to
+    // resolve (no missing keys, no probe needed).
+    const spy = vitest.spyOn(globalThis, 'getComputedStyle')
+    activeSpies.push(spy)
+
+    const calls: { keyframes: Keyframe[] }[] = []
+    target.animate = ((kf: Keyframe[], opt: KeyframeAnimationOptions) => {
+      calls.push({ keyframes: kf })
+      return Element.prototype.animate.call(target, kf, opt)
+    }) as Element['animate']
+
+    animate(
+      target,
+      [
+        { width: '10px', height: '1em' },
+        { width: '50px', height: '5em' },
+      ],
+      { duration: 10 },
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+    const keyframesByKey = new Map<string, Keyframe[]>()
+    for (const c of calls) {
+      const key = Object.keys(c.keyframes[0]!)[0]!
+      keyframesByKey.set(key, c.keyframes)
+    }
+    expect(keyframesByKey.get('width')).toEqual([{ width: '10px' }, { width: '50px' }])
+    expect(keyframesByKey.get('height')).toEqual([{ height: '1em' }, { height: '5em' }])
+  })
+
+  test('restores pre-existing inline value after probing', () => {
+    const target = el()
+    target.style.width = '50px'
+
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'width' && probe === '10rem') return '160px'
+      return undefined
+    })
+
+    animate(target, [{ width: '10rem' }, { width: '300px' }], { duration: 10 })
+
+    expect(target.style.width).toBe('50px')
+  })
+
+  test('clears inline value after probing when it was empty before', () => {
+    const target = el()
+
+    mockComputedFromProbe(target, (key, probe) => {
+      if (key === 'transform' && probe === 'translate(1rem)') {
+        return 'matrix(1, 0, 0, 1, 16, 0)'
+      }
+      return undefined
+    })
+
+    animate(target, [{ transform: 'translate(1rem)' }, { transform: 'translate(100px)' }], {
+      duration: 10,
+    })
+
+    // Skipped path also restores: empty inline stays empty.
+    expect(target.style.transform).toBe('')
   })
 })

--- a/test/core/controller.test.ts
+++ b/test/core/controller.test.ts
@@ -1,9 +1,51 @@
-import { describe, expect, test } from 'vite-plus/test'
+import { afterEach, describe, expect, test, vitest } from 'vite-plus/test'
+import type { MockInstance } from 'vite-plus/test'
 
 import { createAnimateController } from '../../src/core'
 
 function el(): HTMLElement {
   return document.createElement('div')
+}
+
+function raf(): Promise<unknown> {
+  return new Promise((resolve) => requestAnimationFrame(resolve))
+}
+
+const activeSpies: MockInstance[] = []
+
+afterEach(() => {
+  while (activeSpies.length) {
+    activeSpies.pop()!.mockRestore()
+  }
+})
+
+/**
+ * Spy on `getComputedStyle` so that, for `target`, any `<n>rem` width probe
+ * resolves to `<n * 16>px` (jsdom doesn't resolve units on its own). This lets
+ * the controller's mixed-unit `px` resolution run in tests.
+ */
+function mockRemResolution(target: HTMLElement): void {
+  const real = globalThis.getComputedStyle
+
+  const spy = vitest
+    .spyOn(globalThis, 'getComputedStyle')
+    .mockImplementation((elt: Element, pseudo?: string | null) => {
+      const cs = real(elt, pseudo)
+      if (elt !== target) return cs
+
+      return new Proxy(cs, {
+        get(t, prop, receiver) {
+          if (prop === 'width') {
+            const probe = target.style.width
+            const match = /^(\d+(?:\.\d+)?)rem$/.exec(probe)
+            if (match) return `${parseFloat(match[1]!) * 16}px`
+          }
+          return Reflect.get(t, prop, receiver)
+        },
+      }) as CSSStyleDeclaration
+    })
+
+  activeSpies.push(spy)
 }
 
 describe('AnimationController', () => {
@@ -111,6 +153,36 @@ describe('AnimationController', () => {
     controller.setStyle({ width: '0' })
     controller.stop()
     expect(target.style.width).toContain('%')
+  })
+
+  test('stopping a resolved mixed-unit animation hands off in px, not the authored unit', async () => {
+    const target = el()
+    mockRemResolution(target)
+
+    const controller = createAnimateController(target)
+    controller.setOptions({ duration: 1000 })
+
+    // Start at 300px, then animate toward 10rem (resolves to 160px).
+    controller.setStyle({ width: '300px' }, { animate: false })
+    controller.setStyle({ width: '10rem' })
+
+    await raf()
+    controller.stop()
+
+    // The animation was frozen at a px value between 160 and 300.
+    const stoppedWidth = parseFloat(target.style.width)
+    expect(target.style.width).toContain('px')
+    expect(stoppedWidth).toBeGreaterThan(150)
+    expect(stoppedWidth).toBeLessThan(310)
+
+    // Re-fire toward 300px. The new `from` must reuse the stopped px value as
+    // px. If it were mislabeled `rem`, the mock would resolve it to ~16x and the
+    // start value would jump into the thousands.
+    controller.setStyle({ width: '300px' })
+
+    const restartWidth = parseFloat(target.style.width)
+    expect(target.style.width).toContain('px')
+    expect(Math.abs(restartWidth - stoppedWidth)).toBeLessThan(5)
   })
 
   test('register finish listener for the current animation', () => {


### PR DESCRIPTION
## Summary

Enable animating values whose `from`/`to` mix `px` with a non-`px` length unit (`rem` / `em` / `%`) by resolving the non-`px` side to `px` for the duration of the animation, so the spring runs and renders in a single dimension.

- **Unit resolution in `animate()`** — For each slot where `from`/`to` mix `px` with another non-empty length unit, resolve the non-`px` side to `px` by probing the live element via `getComputedStyle`. The resolution is skipped (slot left unchanged) when the resolved string doesn't share the same `wraps` structure / expected units, which filters out cases like `transform` matrix expansion, shorthand expansion, `%`-retaining contexts, and custom properties.
- **Fix handoff unit mismatch** — Carry the resolved unit on the `Attachment` and read it via `SpringComputed.unit()` paired with the live `current()` value. This fixes a bug where stopping or re-firing mid-flight captured the `px` value but re-tagged it with the authored unit (e.g. `rem`), causing the next animation's `from` to be reinterpreted and the start value to jump ~16x.
- **`demo/unit-mismatch`** — Add a demo exercising mixed-unit animations such as `10rem ↔ 300px`.
- Add regression tests for unit resolution and the stop/re-fire handoff in `test/core/animate.test.ts` and `test/core/controller.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced animation handling for CSS properties with mixed units across `from` and `to` states (e.g., rem to px, percentage to px).

* **Documentation**
  * Added new demo page showcasing unit mismatch animation scenarios with various CSS unit combinations.

* **Tests**
  * Added comprehensive test coverage for unit conversion behavior in animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->